### PR TITLE
Allow the bridge to prevent the user from depositing if it would violate a cap

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@bitcoinerlab/secp256k1": "1.1.1",
     "@headlessui/react": "2.1.2",
     "@heroicons/react": "2.1.5",
-    "@stacks/transactions": "7.0.2",
+    "@stacks/transactions": "^7.0.2",
+    "@tanstack/react-query": "^5.61.5",
     "add": "2.0.6",
     "babel-loader": "9.2.1",
     "c32check": "2.0.0",
@@ -28,7 +29,8 @@
     "sats-connect": "3.0.1",
     "server-only": "^0.0.1",
     "webpack": "5.95.0",
-    "yarn": "1.22.22"
+    "yarn": "1.22.22",
+    "yup": "^1.4.0"
   },
   "devDependencies": {
     "@leather.io/rpc": "^2.1.20",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "server-only": "^0.0.1",
     "webpack": "5.95.0",
     "yarn": "1.22.22",
-    "yup": "^1.4.0"
+    "yup": "1.4.0"
   },
   "devDependencies": {
     "@leather.io/rpc": "^2.1.20",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "sats-connect": "3.0.1",
+    "server-only": "^0.0.1",
     "webpack": "5.95.0",
     "yarn": "1.22.22"
   },

--- a/src/actions/get-current-sbtc-supply.ts
+++ b/src/actions/get-current-sbtc-supply.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { env } from "@/env";
+import {
+  fetchCallReadOnlyFunction,
+  type ResponseOkCV,
+  type UIntCV,
+} from "@stacks/transactions";
+import { type StacksNetworkName } from "@stacks/network";
+export default async function getCurrentSbtcSupply() {
+  const response = (await fetchCallReadOnlyFunction({
+    contractAddress: env.SBTC_CONTRACT_DEPLOYER!,
+    contractName: "sbtc-token",
+    functionName: "get-total-supply",
+    functionArgs: [],
+    network:
+      env.WALLET_NETWORK === "sbtcDevenv"
+        ? "devnet"
+        : (env.WALLET_NETWORK as StacksNetworkName),
+    senderAddress: env.SBTC_CONTRACT_DEPLOYER!,
+  })) as ResponseOkCV<UIntCV>;
+
+  return response;
+}

--- a/src/actions/get-emily-limits.ts
+++ b/src/actions/get-emily-limits.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import { env } from "@/env";
+type EmilyLimits = {
+  pegCap: null | number;
+  perDepositCap: null | number;
+  perWithdrawalCap: null | number;
+  accountCaps: AccountCaps;
+};
+
+type AccountCaps = {};
+
+export default async function getEmilyLimits() {
+  const res = await fetch(`${env.EMILY_URL}/limits`);
+  const json = (await res.json()) as EmilyLimits;
+  // exclude account caps
+  return {
+    // if null, it means unlimited
+    pegCap: json.pegCap || Infinity,
+    perDepositCap: json.perDepositCap || Infinity,
+    perWithdrawalCap: json.perWithdrawalCap || Infinity,
+  };
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,6 @@ import { Provider } from "jotai";
 import { store } from "@/util/atoms";
 
 import RenderNotifications from "@/comps/RenderNotifications";
-import { Suspense } from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "@/query/client";
 
@@ -23,8 +22,8 @@ export default function RootLayout({
     <html lang="en">
       <Provider store={store}>
         <QueryClientProvider client={queryClient}>
-                <RenderNotifications />
-                <body className={inter.className}>{children}</body>
+          <RenderNotifications />
+          <body className={inter.className}>{children}</body>
         </QueryClientProvider>
       </Provider>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,9 @@ import { Provider } from "jotai";
 import { store } from "@/util/atoms";
 
 import RenderNotifications from "@/comps/RenderNotifications";
+import { Suspense } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { queryClient } from "@/query/client";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -19,8 +22,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <Provider store={store}>
-        <RenderNotifications />
-        <body className={inter.className}>{children}</body>
+        <QueryClientProvider client={queryClient}>
+                <RenderNotifications />
+                <body className={inter.className}>{children}</body>
+        </QueryClientProvider>
       </Provider>
     </html>
   );

--- a/src/comps/core/FlowButtons.tsx
+++ b/src/comps/core/FlowButtons.tsx
@@ -5,23 +5,26 @@ type ButtonProps = {
   onClick: () => void;
   isValid?: boolean;
   type?: "button" | "submit" | "reset";
+  disabled?: boolean;
 };
 export const PrimaryButton = ({
   children,
   onClick,
   isValid = true,
+  disabled = false,
   type = "button",
 }: ButtonProps) => {
   return (
     <button
+      disabled={disabled}
       type={type}
-      className="w-40 rounded-lg py-3 flex justify-center items-center flex-row bg-orange"
+      className="w-40 rounded-lg py-3 flex justify-center items-center flex-row bg-orange disabled:opacity-50 disabled:cursor-not-allowed "
       onClick={onClick}
     >
       <p
         className={classNames(
           " text-md tracking-wider font-Matter font-bold",
-          isValid ? "text-black" : "text-black"
+          isValid ? "text-black" : "text-black",
         )}
       >
         {children}
@@ -45,7 +48,7 @@ export const SecondaryButton = ({
       <p
         className={classNames(
           " text-lg tracking-wider font-Matter font-semibold",
-          isValid ? "text-black" : "text-black"
+          isValid ? "text-black" : "text-black",
         )}
       >
         {children}

--- a/src/comps/core/Form.tsx
+++ b/src/comps/core/Form.tsx
@@ -56,7 +56,7 @@ export const FlowForm = ({
           disabled={disabled}
           className={`w-full py-2 border-b-2 bg-transparent text-xl text-black focus:outline-none placeholder-gray-300 ${
             formik.isValid ? "border-orange" : "border-red-300"
-          } transition-colors duration-500`}
+          } transition-colors duration-500 disabled:opacity-50 disabled:cursor-not-allowed`}
         />
         <p className="text-red-500 text-sm h-4">{formik.errors[nameKey]}</p>
       </div>
@@ -66,7 +66,7 @@ export const FlowForm = ({
           <PrimaryButton
             type="submit"
             onClick={formik.handleSubmit}
-            isValid={formik.isValid}
+            disabled={!formik.isValid || disabled}
           >
             NEXT
           </PrimaryButton>

--- a/src/comps/core/Form.tsx
+++ b/src/comps/core/Form.tsx
@@ -3,6 +3,7 @@ import { PrimaryButton } from "./FlowButtons";
 import { useAtomValue, useSetAtom } from "jotai";
 import { showConnectWalletAtom, walletInfoAtom } from "@/util/atoms";
 import { useMemo } from "react";
+import { Schema as YupSchema } from "yup";
 // this is supposed to be as reusable as possible given all the flows are very similar in order and action
 type FlowFormProps = {
   nameKey: string;
@@ -11,6 +12,8 @@ type FlowFormProps = {
   handleSubmit: (value: string | undefined) => void;
   type?: "text" | "number";
   children?: React.ReactNode;
+  validationSchema?: YupSchema;
+  disabled?: boolean;
 };
 // tailwind div that reset all default form styles
 
@@ -21,6 +24,8 @@ export const FlowForm = ({
   handleSubmit,
   type,
   children,
+  validationSchema,
+  disabled,
 }: FlowFormProps) => {
   const walletInfo = useAtomValue(walletInfoAtom);
   const isConnected = useMemo(() => !!walletInfo.selectedWallet, [walletInfo]);
@@ -33,11 +38,12 @@ export const FlowForm = ({
     onSubmit: (values) => {
       handleSubmit(values[nameKey]);
     },
+    validationSchema,
   });
 
   return (
     <form
-      className="w-full flex flex-1 flex-col gap-14 justify-end"
+      className="w-full flex flex-1 flex-col gap-14 justify-end font-Matter"
       onSubmit={formik.handleSubmit}
     >
       <div className="relative ">
@@ -47,10 +53,12 @@ export const FlowForm = ({
           placeholder={placeholder}
           value={formik.values[nameKey]}
           onChange={formik.handleChange}
+          disabled={disabled}
           className={`w-full py-2 border-b-2 bg-transparent text-xl text-black focus:outline-none placeholder-gray-300 ${
-            formik.isValid ? "border-orange" : "border-midGray"
+            formik.isValid ? "border-orange" : "border-red-300"
           } transition-colors duration-500`}
         />
+        <p className="text-red-500 text-sm h-4">{formik.errors[nameKey]}</p>
       </div>
       <div className="w-full flex-row flex justify-between items-center">
         {children}

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,3 +1,6 @@
+// MUST NOT BE USED BY CLIENT
+import "server-only";
+
 export const env = {
   BITCOIND_URL: process.env.BITCOIND_URL || "http://localhost:18443",
   EMILY_URL: process.env.EMILY_URL,

--- a/src/env.ts
+++ b/src/env.ts
@@ -8,7 +8,7 @@ export const env = {
     process.env.MEMPOOL_API_URL || "http://localhost:8083/api/v1/",
   BITCOIN_RPC_USER_NAME: process.env.BITCOIN_RPC_USER_NAME || "devnet",
   BITCOIN_RPC_PASSWORD: process.env.BITCOIN_RPC_PASSWORD || "devnet",
-  WALLET_NETWORK: process.env.WALLET_NETWORK,
+  WALLET_NETWORK: process.env.WALLET_NETWORK || "sbtcDevenv",
   SBTC_CONTRACT_DEPLOYER: process.env.SBTC_CONTRACT_DEPLOYER,
   SIGNER_AGGREGATE_KEY: process.env.SIGNER_AGGREGATE_KEY,
 };

--- a/src/hooks/use-mint-caps.ts
+++ b/src/hooks/use-mint-caps.ts
@@ -1,0 +1,65 @@
+import getCurrentSbtcSupply from "@/actions/get-current-sbtc-supply";
+import getEmilyLimits from "@/actions/get-emily-limits";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
+
+export default function useMintCaps() {
+  const {
+    data: emilyLimitsData,
+    isFetching: isLoadingEmilyLimits,
+    refetch: refetchEmilyLimits,
+  } = useQuery({
+    queryKey: ["deposit-max-fee"],
+    queryFn: () => getEmilyLimits(),
+  });
+  const {
+    data: sbtcSupplyData,
+    refetch: refetchSbtcSupply,
+    isFetching: isLoadingSbtcSupply,
+  } = useQuery({
+    queryKey: ["current-sbtc-supply"],
+    queryFn: () => getCurrentSbtcSupply(),
+  });
+  const isLoading = isLoadingEmilyLimits || isLoadingSbtcSupply;
+  const refetchPegData = useCallback(async () => {
+    const { data: currentEmilyLimitsData } = await refetchEmilyLimits();
+    const { data: currentSbtcSupplyData } = await refetchSbtcSupply();
+
+    return {
+      currentEmilyLimitsData,
+      currentSbtcSupplyData,
+    };
+  }, [refetchEmilyLimits, refetchSbtcSupply]);
+
+  const isWithinDepositLimits = useCallback(
+    async (amount: number) => {
+      const { currentEmilyLimitsData, currentSbtcSupplyData } =
+        await refetchPegData();
+      if (!currentEmilyLimitsData || !currentSbtcSupplyData) {
+        return false;
+      }
+      const withinMintCap =
+        currentEmilyLimitsData.pegCap >
+        Number(currentSbtcSupplyData.value.value) + amount;
+      const depositLessThanMax = currentEmilyLimitsData.perDepositCap >= amount;
+      return withinMintCap && depositLessThanMax;
+    },
+    [refetchPegData],
+  );
+
+  const currentCap = useMemo(() => {
+    const currentPerDepositCap = emilyLimitsData?.perDepositCap ?? 0;
+    const currentMintable =
+      (emilyLimitsData?.pegCap ?? 0) - Number(sbtcSupplyData?.value.value ?? 0);
+    return Math.min(currentPerDepositCap, currentMintable);
+  }, [
+    emilyLimitsData?.pegCap,
+    emilyLimitsData?.perDepositCap,
+    sbtcSupplyData?.value.value,
+  ]);
+  return {
+    currentCap,
+    isWithinDepositLimits,
+    isLoading,
+  };
+}

--- a/src/query/client.ts
+++ b/src/query/client.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3557,6 +3557,11 @@ serialize-javascript@^6.0.1:
   dependencies:
     randombytes "^2.1.0"
 
+server-only@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/server-only/-/server-only-0.0.1.tgz#0f366bb6afb618c37c9255a314535dc412cd1c9e"
+  integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==
+
 set-function-length@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"

--- a/yarn.lock
+++ b/yarn.lock
@@ -450,6 +450,18 @@
   dependencies:
     tslib "^2.4.0"
 
+"@tanstack/query-core@5.61.5":
+  version "5.61.5"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.61.5.tgz#3ba80527f6474b5edbf348c1b0a6254b3cdfe160"
+  integrity sha512-iG5vqurEOEbv+paP6kW3zPENa99kSIrd1THISJMaTwVlJ+N5yjVDNOUwp9McK2DWqWCXM3v13ubBbAyhxT78UQ==
+
+"@tanstack/react-query@^5.61.5":
+  version "5.61.5"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.61.5.tgz#abe26e5f2d7c9c6c0643579abfd9119ac22a88c8"
+  integrity sha512-rjy8aqPgBBEz/rjJnpnuhi8TVkVTorMUsJlM3lMvrRb5wK6yzfk34Er0fnJ7w/4qyF01SnXsLB/QsTBsLF5PaQ==
+  dependencies:
+    "@tanstack/query-core" "5.61.5"
+
 "@tanstack/react-virtual@^3.8.1":
   version "3.8.4"
   resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.8.4.tgz#7f5d8a71f525976c98be46fecd3dbee2d90b5dac"
@@ -3287,10 +3299,10 @@ prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+property-expr@^2.0.5:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.6.tgz#f77bc00d5928a6c748414ad12882e83f24aec1e8"
+  integrity sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==
 
 psl@^1.1.28:
   version "1.9.0"
@@ -3893,6 +3905,11 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
+tiny-case@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
+  integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
+
 tiny-warning@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
@@ -3904,6 +3921,11 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
 
 tough-cookie@~2.5.0:
   version "2.5.0"
@@ -3971,6 +3993,11 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 typed-array-buffer@^1.0.2:
   version "1.0.2"
@@ -4273,6 +4300,16 @@ yocto-queue@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.1.1.tgz#fef65ce3ac9f8a32ceac5a634f74e17e5b232110"
   integrity sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==
+
+yup@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.4.0.tgz#898dcd660f9fb97c41f181839d3d65c3ee15a43e"
+  integrity sha512-wPbgkJRCqIf+OHyiTBQoJiP5PFuAXaWiJK6AmYkzQAh5/c2K9hzSApBZG5wV9KoKSePF7sAxmNSvh/13YHkFDg==
+  dependencies:
+    property-expr "^2.0.5"
+    tiny-case "^1.0.3"
+    toposort "^2.0.2"
+    type-fest "^2.19.0"
 
 zod@3.23.8:
   version "3.23.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -418,7 +418,7 @@
   resolved "https://registry.yarnpkg.com/@stacks/stacks-blockchain-api-types/-/stacks-blockchain-api-types-7.8.2.tgz#879c4a886cfbdecf5ae834afc2e1ab2b9527dc9c"
   integrity sha512-wcDSdgIZx/ttQfUTPtGJOIyEkTOjmCsC79TaIyxTIiihSgrGppqTuzkwHD/DyuQkcJtUZvDTxMsAXkBKShE1kw==
 
-"@stacks/transactions@7.0.2":
+"@stacks/transactions@^7.0.2":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@stacks/transactions/-/transactions-7.0.2.tgz#fe4a3ece5a779b65a1d7cbef9393f13dc7ec7f85"
   integrity sha512-m2bvchqUeYv1ttXuC0EukW8UX4xBXTDcYb8bXmfI1RG89HXAvvCCgr5aiadU6zbutgoXvm8mquDt3nww0PO4Jg==
@@ -450,17 +450,17 @@
   dependencies:
     tslib "^2.4.0"
 
-"@tanstack/query-core@5.61.5":
-  version "5.61.5"
-  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.61.5.tgz#3ba80527f6474b5edbf348c1b0a6254b3cdfe160"
-  integrity sha512-iG5vqurEOEbv+paP6kW3zPENa99kSIrd1THISJMaTwVlJ+N5yjVDNOUwp9McK2DWqWCXM3v13ubBbAyhxT78UQ==
+"@tanstack/query-core@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.62.0.tgz#94022c9fde3b8c60e69828b726bd0df535dcacf9"
+  integrity sha512-sx38bGrqF9bop92AXOvzDr0L9fWDas5zXdPglxa9cuqeVSWS7lY6OnVyl/oodfXjgOGRk79IfCpgVmxrbHuFHg==
 
-"@tanstack/react-query@5.61.5":
-  version "5.61.5"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.61.5.tgz#abe26e5f2d7c9c6c0643579abfd9119ac22a88c8"
-  integrity sha512-rjy8aqPgBBEz/rjJnpnuhi8TVkVTorMUsJlM3lMvrRb5wK6yzfk34Er0fnJ7w/4qyF01SnXsLB/QsTBsLF5PaQ==
+"@tanstack/react-query@^5.61.5":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.62.0.tgz#db7d4ec58a0db69b105e2d8bd249acfb20653825"
+  integrity sha512-tj2ltjAn2a3fs+Dqonlvs6GyLQ/LKVJE2DVSYW+8pJ3P6/VCVGrfqv5UEchmlP7tLOvvtZcOuSyI2ooVlR5Yqw==
   dependencies:
-    "@tanstack/query-core" "5.61.5"
+    "@tanstack/query-core" "5.62.0"
 
 "@tanstack/react-virtual@^3.8.1":
   version "3.8.4"
@@ -3304,6 +3304,11 @@ property-expr@^2.0.5:
   resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.6.tgz#f77bc00d5928a6c748414ad12882e83f24aec1e8"
   integrity sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 psl@^1.1.28:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
@@ -3569,7 +3574,7 @@ serialize-javascript@^6.0.1:
   dependencies:
     randombytes "^2.1.0"
 
-server-only@0.0.1:
+server-only@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/server-only/-/server-only-0.0.1.tgz#0f366bb6afb618c37c9255a314535dc412cd1c9e"
   integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -455,7 +455,7 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.61.5.tgz#3ba80527f6474b5edbf348c1b0a6254b3cdfe160"
   integrity sha512-iG5vqurEOEbv+paP6kW3zPENa99kSIrd1THISJMaTwVlJ+N5yjVDNOUwp9McK2DWqWCXM3v13ubBbAyhxT78UQ==
 
-"@tanstack/react-query@^5.61.5":
+"@tanstack/react-query@5.61.5":
   version "5.61.5"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.61.5.tgz#abe26e5f2d7c9c6c0643579abfd9119ac22a88c8"
   integrity sha512-rjy8aqPgBBEz/rjJnpnuhi8TVkVTorMUsJlM3lMvrRb5wK6yzfk34Er0fnJ7w/4qyF01SnXsLB/QsTBsLF5PaQ==
@@ -3569,7 +3569,7 @@ serialize-javascript@^6.0.1:
   dependencies:
     randombytes "^2.1.0"
 
-server-only@^0.0.1:
+server-only@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/server-only/-/server-only-0.0.1.tgz#0f366bb6afb618c37c9255a314535dc412cd1c9e"
   integrity sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==
@@ -4301,7 +4301,7 @@ yocto-queue@^1.0.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.1.1.tgz#fef65ce3ac9f8a32ceac5a634f74e17e5b232110"
   integrity sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==
 
-yup@^1.4.0:
+yup@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/yup/-/yup-1.4.0.tgz#898dcd660f9fb97c41f181839d3d65c3ee15a43e"
   integrity sha512-wPbgkJRCqIf+OHyiTBQoJiP5PFuAXaWiJK6AmYkzQAh5/c2K9hzSApBZG5wV9KoKSePF7sAxmNSvh/13YHkFDg==


### PR DESCRIPTION
## Description

As a user I want to submit a sBTC bridge request only if the deposit amount does not exceeds the limits for deposit. This is an important validation for bridging sBTC so that btc isn't lost or extra work is needed to retrieve it. This PR adds an action to get the limits from the emily api, and a client side validation for the btc amount input.



https://github.com/user-attachments/assets/30b2191b-7cb2-4f3e-b162-8f9c5428fdfd



<img width="865" alt="image" src="https://github.com/user-attachments/assets/0736d9f5-93c1-4962-94db-33910fa6203b">


For details refer to issue https://github.com/stacks-network/sbtc/issues/859

## Type of Change
- Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No
