### PR TITLE
remove unused env atom

### DIFF
--- a/src/comps/Deposit.tsx
+++ b/src/comps/Deposit.tsx
@@ -22,8 +22,6 @@ import { useAtomValue } from "jotai";
 import {
   bridgeConfigAtom,
   depositMaxFeeAtom,
-  ENV,
-  envAtom,
   walletInfoAtom,
   WalletProvider,
 } from "@/util/atoms";

--- a/src/util/atoms.ts
+++ b/src/util/atoms.ts
@@ -18,14 +18,6 @@ export const bridgeConfigAtom = atom<BridgeConfig>({
 });
 export const depositMaxFeeAtom = atom(80000);
 
-export enum ENV {
-  MAINNET = "MAINNET",
-  TESTNET = "TESTNET",
-  DEVENV = "DEVENV",
-}
-
-export const envAtom = atom(ENV.TESTNET);
-
 export const showConnectWalletAtom = atom<boolean>(false);
 
 export const eventsAtom = atom<NotificationEventType[]>([]);


### PR DESCRIPTION
This PR should fix the build issue regarding an unused import and removes a vestige atom that is now consolidated under wallet info atom