### PR TITLE
Reclaim opchecksig

### DIFF
--- a/src/actions/bitcoinClient.ts
+++ b/src/actions/bitcoinClient.ts
@@ -84,3 +84,19 @@ export const getRawTransaction = async (
   const result = await fetch(`${baseURL}/tx/${txid}`);
   return await result.json();
 };
+
+// Function to transmit a raw transaction to the network
+export const transmitRawTransaction = async (hex: string): Promise<any> => {
+  const baseURL =
+    env.WALLET_NETWORK === "mainnet" ? env.MEMPOOL_API_URL : "/api/proxy";
+  const result = await fetch(`${baseURL}/tx`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ hex }),
+  });
+
+  console.log("result", result.json());
+  return await result.json();
+};

--- a/src/actions/bitcoinClient.ts
+++ b/src/actions/bitcoinClient.ts
@@ -87,16 +87,19 @@ export const getRawTransaction = async (
 
 // Function to transmit a raw transaction to the network
 export const transmitRawTransaction = async (hex: string): Promise<any> => {
-  const baseURL =
-    env.WALLET_NETWORK === "mainnet" ? env.MEMPOOL_API_URL : "/api/proxy";
-  const result = await fetch(`${baseURL}/tx`, {
+  const baseURL = env.MEMPOOL_URL;
+
+  console.log("hex", hex);
+  const result = await fetch(`${baseURL}/api/tx`, {
     method: "POST",
     headers: {
-      "Content-Type": "application/json",
+      "Content-Type": "text/plain",
     },
-    body: JSON.stringify({ hex }),
+    body: hex,
   });
 
-  console.log("result", result.json());
-  return await result.json();
+  const res = await result.text();
+  console.log("res", res);
+
+  return res;
 };

--- a/src/app/api/tx/route.ts
+++ b/src/app/api/tx/route.ts
@@ -11,7 +11,7 @@ export async function GET(req: NextRequest) {
       throw new Error("btcAddress is required");
     }
 
-    const url = `${env.MEMPOOL_API_URL}/tx/${txId}`;
+    const url = `${env.MEMPOOL_URL}/api/tx/${txId}`;
 
     const response = await fetch(url, {
       method: "GET",

--- a/src/comps/Deposit.tsx
+++ b/src/comps/Deposit.tsx
@@ -250,13 +250,15 @@ const DepositFlowConfirm = ({
         return;
       }
 
-      // const reclaimPublicKey = paymentAddress.publicKey;
+      const reclaimPublicKey = paymentAddress.publicKey;
 
       // Parse lockTime from env variable
       const parsedLockTime = parseInt(lockTime || "144");
 
       // Create the reclaim script and convert to Buffer
-      const reclaimScript = Buffer.from(createReclaimScript(parsedLockTime));
+      const reclaimScript = Buffer.from(
+        createReclaimScript(parsedLockTime, reclaimPublicKey),
+      );
 
       const reclaimScriptHex = uint8ArrayToHexString(reclaimScript);
 
@@ -273,6 +275,7 @@ const DepositFlowConfirm = ({
         maxFee,
         parsedLockTime,
         getBitcoinNetwork(config.WALLET_NETWORK),
+        reclaimPublicKey,
       );
 
       let txId = "";

--- a/src/comps/ReclaimManager.tsx
+++ b/src/comps/ReclaimManager.tsx
@@ -393,8 +393,10 @@ const ReclaimDeposit = ({
       if (response && response.result) {
         const signedTxHex = response.result.hex;
 
+        console.log("signedTxHex", signedTxHex);
         const finalizedTxHex = finalizePsbt(signedTxHex);
 
+        console.log("finalizedTxHex", finalizedTxHex);
         const transactionId = createTransactionFromHex(finalizedTxHex);
 
         // set a query params to the transaction id as reclaimTxId and updated the status

--- a/src/comps/ReclaimManager.tsx
+++ b/src/comps/ReclaimManager.tsx
@@ -20,6 +20,7 @@ import { SignatureHash } from "@leather.io/rpc";
 import { Step } from "./deposit-stepper";
 import { getReclaimInfo } from "@/util/tx-utils";
 import { ReclaimStatus, useReclaimStatus } from "@/hooks/use-reclaim-status";
+import { transmitRawTransaction } from "@/actions/bitcoinClient";
 
 enum RECLAIM_STEP {
   LOADING = "LOADING",
@@ -92,9 +93,12 @@ const ReclaimManager = () => {
     }
   }, []);
 
-  const setStep = useCallback((newStep: RECLAIM_STEP) => {
-    _setStep(newStep);
-  }, []);
+  const setStep = useCallback(
+    (newStep: RECLAIM_STEP) => {
+      _setStep(newStep);
+    },
+    [searchParams],
+  );
 
   const renderStep = () => {
     switch (step) {
@@ -399,6 +403,12 @@ const ReclaimDeposit = ({
         console.log("finalizedTxHex", finalizedTxHex);
         const transactionId = createTransactionFromHex(finalizedTxHex);
 
+        const broadcastTransaction = await transmitRawTransaction(
+          finalizedTxHex,
+        );
+
+        console.log("broadcastTransaction", broadcastTransaction);
+
         console.log("transactionId", transactionId);
         // set a query params to the transaction id as reclaimTxId and updated the status
 
@@ -479,15 +489,43 @@ const CurrentStatusReclaim = ({
     return steps.findIndex((step) => step === status);
   }, [status]);
 
+<<<<<<< HEAD
   const mempoolUrl = useMemo(() => {
     return `${MEMPOOL_URL}/tx/${txId}`;
   }, [MEMPOOL_URL, txId]);
+=======
+  const memepoolUrl = useMemo(() => {
+    const testNetUrl = "https://mempool.bitcoin.regtest.hiro.so/tx/";
+    const mainnetUrl = "https://mempool.space/tx/";
+
+    const apiUrl = walletNetwork === "sbtcTestnet" ? testNetUrl : mainnetUrl;
+
+    return `${apiUrl}${txId}`;
+  }, []);
+
+  const renderCurrenStatusText = () => {
+    if (status === ReclaimStatus.Pending) {
+      return (
+        <SubText>Reclaim transaction is pending confirmation on chain</SubText>
+      );
+    } else if (status === ReclaimStatus.Completed) {
+      return <SubText>Reclaim transaction has been confirmed on chain</SubText>;
+    } else {
+      return (
+        <SubText>
+          Something went wrong getting the status, please reach out for help
+        </SubText>
+      );
+    }
+  };
+>>>>>>> e9d5523 (feature - add broadcast)
   return (
     <FlowLoaderContainer showLoader={showLoader}>
       <>
         <div className="w-full flex flex-row items-center justify-between">
-          <Heading>Reclaim Transaction Status</Heading>
+          <Heading>Reclaim Status</Heading>
         </div>
+        {renderCurrenStatusText()}
         <div className="flex flex-col  gap-2">
           <div className="flex flex-col gap-1">
             <SubText>Amount To Reclaim</SubText>
@@ -510,7 +548,7 @@ const CurrentStatusReclaim = ({
           </div>
         </div>
 
-        <div className="flex flex-col mt-8 gap-4 w-full ">
+        <div className="flex flex-col mt-2 gap-4 w-full ">
           <ol className="flex items-center w-full text-xs text-gray-900 font-medium sm:text-base text-black">
             <Step
               currentStep={currentStep}
@@ -528,5 +566,16 @@ const CurrentStatusReclaim = ({
         </div>
       </>
     </FlowLoaderContainer>
+  );
+};
+
+const TransactionConfirmation = () => {
+  return (
+    <div
+      style={{
+        backgroundColor: "rgba(253, 157, 65, 0.1)",
+      }}
+      className="absolute m-auto inset-0 w-96 h-96 rounded-lg flex flex-col items-center justify-center gap"
+    ></div>
   );
 };

--- a/src/comps/ReclaimManager.tsx
+++ b/src/comps/ReclaimManager.tsx
@@ -399,6 +399,7 @@ const ReclaimDeposit = ({
         console.log("finalizedTxHex", finalizedTxHex);
         const transactionId = createTransactionFromHex(finalizedTxHex);
 
+        console.log("transactionId", transactionId);
         // set a query params to the transaction id as reclaimTxId and updated the status
 
         router.push(`/reclaim?reclaimTxId=${transactionId}`);

--- a/src/comps/ReclaimManager.tsx
+++ b/src/comps/ReclaimManager.tsx
@@ -401,10 +401,7 @@ const ReclaimDeposit = ({
       if (response && response.result) {
         const signedTxHex = response.result.hex;
 
-        console.log("signedTxHex", signedTxHex);
         const finalizedTxHex = finalizePsbt(signedTxHex);
-
-        console.log("finalizedTxHex", finalizedTxHex);
 
         await broadcastTransaction(finalizedTxHex);
       } else {
@@ -430,11 +427,13 @@ const ReclaimDeposit = ({
         });
         return;
       }
+      notify({
+        type: NotificationStatusType.SUCCESS,
+        message: "Reclaim transaction broadcasted",
+      });
+
       const transactionId = createTransactionFromHex(finalizedTxHex);
 
-      console.log("broadcastTransaction", broadcastTransaction);
-
-      console.log("transactionId", transactionId);
       // set a query params to the transaction id as reclaimTxId and updated the status
 
       router.push(`/reclaim?reclaimTxId=${transactionId}`);

--- a/src/hooks/use-reclaim-status.ts
+++ b/src/hooks/use-reclaim-status.ts
@@ -25,8 +25,10 @@ export const useReclaimStatus = (txId: string) => {
         });
 
         let status = ReclaimStatus.Pending;
+
         if (reclaimTx.status.confirmed) {
           status = ReclaimStatus.Completed;
+          clearInterval(interval);
         }
 
         setReclaimStatus(status);

--- a/src/util/reclaimHelper.tsx
+++ b/src/util/reclaimHelper.tsx
@@ -23,7 +23,7 @@ export const finalizePsbt = (psbtHex: string) => {
 
 export const createTransactionFromHex = (hex: string) => {
   const transaction = bitcoin.Transaction.fromHex(hex);
-  return transaction;
+  return transaction.getId();
 };
 type ReclaimDepositProps = {
   feeAmount: number;

--- a/src/util/reclaimHelper.tsx
+++ b/src/util/reclaimHelper.tsx
@@ -12,6 +12,7 @@ export const finalizePsbt = (psbtHex: string) => {
     const network = bitcoin.networks.regtest;
 
     const psbt = bitcoin.Psbt.fromHex(psbtHex, { network });
+    psbt.finalizeAllInputs();
 
     return psbt.extractTransaction().toHex();
   } catch (err) {
@@ -110,7 +111,7 @@ export const constructPsbtForReclaim = ({
 
   const leafIndexFinalizerFn = buildLeafIndexFinalizer(tapLeafScript, lockTime);
 
-  psbt.finalizeInput(0, leafIndexFinalizerFn);
+  //psbt.finalizeInput(0, leafIndexFinalizerFn);
 
   // Add the fee payer inputs
 

--- a/src/util/reclaimHelper.tsx
+++ b/src/util/reclaimHelper.tsx
@@ -25,10 +25,10 @@ export const createTransactionFromHex = (hex: string) => {
   const transaction = bitcoin.Transaction.fromHex(hex);
   return transaction.getId();
 };
+
 type ReclaimDepositProps = {
   feeAmount: number;
   depositAmount: number;
-
   lockTime: number;
   depositScript: string;
   reclaimScript: string;
@@ -108,10 +108,6 @@ export const constructPsbtForReclaim = ({
     },
     tapLeafScript: [tapLeafScript],
   });
-
-  const leafIndexFinalizerFn = buildLeafIndexFinalizer(tapLeafScript, lockTime);
-
-  //psbt.finalizeInput(0, leafIndexFinalizerFn);
 
   // Add the fee payer inputs
 


### PR DESCRIPTION
PR ensure user can properly reclaim their bitcoin after a failed deposit sweep (or a cap limit reach) after their the block locktime has been surpassed.

How is this done?

```ts
  const buildScript = script.compile([
    lockTimeEncoded,
    opcodes.OP_CHECKSEQUENCEVERIFY,
    opcodes.OP_DROP,
    schnorPublicKey,
    opcodes.OP_CHECKSIG,
  ]);
  ```
  
  The above is the reclaim script used as the second leaf for the p2tr deposit transaction (first being the deposit script)
  
  This script leverages 2 main op codes 
  - `OP_CHECKSEQUENCEVERIFY` to ensure that we can only spend this after the selected amount of blocks have been surpassed defined by `lockTimeEncoded`
  - OP_CHECKSIG which is used to ensure that the signature provided (by the wallets) matches the `schnorPublicKey` associated with the transaction that made the deposit request initially, 