### PR TITLE
Bug - mainnet wallet connect fix

### DIFF
--- a/src/comps/ConnectWallet.tsx
+++ b/src/comps/ConnectWallet.tsx
@@ -54,6 +54,16 @@ const ConnectWallet = ({ onClose }: ConnectWalletProps) => {
           addresses = await getAddressesXverse();
       }
 
+      console.log("WALLET_NETWORK", WALLET_NETWORK);
+      console.log("addresses", addresses);
+      console.log(
+        "test main net thing",
+        !addresses.payment.address.startsWith("bc1") ||
+          // for segwit from xverse
+          !addresses.payment.address.startsWith("1") ||
+          !addresses.payment.address.startsWith("3"),
+      );
+
       if (
         WALLET_NETWORK !== "mainnet" &&
         addresses.payment.address.startsWith("bc1")
@@ -61,10 +71,14 @@ const ConnectWallet = ({ onClose }: ConnectWalletProps) => {
         throw new Error(`Please switch to ${WALLET_NETWORK} network`);
       } else if (
         WALLET_NETWORK === "mainnet" &&
-        (!addresses.payment.address.startsWith("bc1") ||
-          // for segwit from xverse
-          !addresses.payment.address.startsWith("1") ||
-          !addresses.payment.address.startsWith("3"))
+        !addresses.payment.address.startsWith("bc1")
+        /*
+        *readme these checks may not be needed since the address of a wallet for segwit will never start with 1
+        * they may start with 3 if a nested segwit address is used ex (P2SH-Wrapped SegWit)
+           for segwit from xverse
+            ||  !addresses.payment.address.startsWith("1") ||
+           !addresses.payment.address.startsWith("3"))
+          */
       ) {
         throw new Error(`Please switch to ${WALLET_NETWORK} network`);
       }

--- a/src/comps/ConnectWallet.tsx
+++ b/src/comps/ConnectWallet.tsx
@@ -54,16 +54,6 @@ const ConnectWallet = ({ onClose }: ConnectWalletProps) => {
           addresses = await getAddressesXverse();
       }
 
-      console.log("WALLET_NETWORK", WALLET_NETWORK);
-      console.log("addresses", addresses);
-      console.log(
-        "test main net thing",
-        !addresses.payment.address.startsWith("bc1") ||
-          // for segwit from xverse
-          !addresses.payment.address.startsWith("1") ||
-          !addresses.payment.address.startsWith("3"),
-      );
-
       if (
         WALLET_NETWORK !== "mainnet" &&
         addresses.payment.address.startsWith("bc1")

--- a/src/comps/ConnectWallet.tsx
+++ b/src/comps/ConnectWallet.tsx
@@ -53,24 +53,15 @@ const ConnectWallet = ({ onClose }: ConnectWalletProps) => {
         case WalletProvider.XVERSE:
           addresses = await getAddressesXverse();
       }
-
-      if (
-        WALLET_NETWORK !== "mainnet" &&
-        addresses.payment.address.startsWith("bc1")
-      ) {
+      const isMainnetAddress =
+        addresses.payment.address.startsWith("bc1") ||
+        addresses.payment.address.startsWith("3");
+      if (WALLET_NETWORK !== "mainnet" && isMainnetAddress) {
         throw new Error(`Please switch to ${WALLET_NETWORK} network`);
-      } else if (
-        WALLET_NETWORK === "mainnet" &&
-        !addresses.payment.address.startsWith("bc1")
-        /*
-        *readme these checks may not be needed since the address of a wallet for segwit will never start with 1
-        * they may start with 3 if a nested segwit address is used ex (P2SH-Wrapped SegWit)
-           for segwit from xverse
-            ||  !addresses.payment.address.startsWith("1") ||
-           !addresses.payment.address.startsWith("3"))
-          */
-      ) {
-        throw new Error(`Please switch to ${WALLET_NETWORK} network`);
+      } else if (WALLET_NETWORK === "mainnet" && !isMainnetAddress) {
+        throw new Error(
+          `Please switch to ${WALLET_NETWORK} network and use a segwit address`,
+        );
       }
 
       setWalletInfo({


### PR DESCRIPTION
This resolve a bug with Leather and Xverse not being able to connect on mainnet 

- https://www.loom.com/share/5b9d983b41df4814a1cf22c19ffbc613 (sorry for the audio) 

issue was checking if the address for xverse started with (1,2,3)
- This should not happen since xverse supports segwit and not wrapped segwit such as P2SH-Wrapped SegWit.