### PR TITLE
Update footer

### DIFF
--- a/src/comps/footer.tsx
+++ b/src/comps/footer.tsx
@@ -40,7 +40,7 @@ export default function Footer({ liveChatId }: { liveChatId?: string }) {
           </a>
           <a
             key="docs"
-            href="https://docs.stacks.co"
+            href="https://docs.stacks.co/concepts/sbtc"
             target="_blank"
             rel="noreferrer"
             className="text-black font-light text-sm"


### PR DESCRIPTION
## Description

This PR changes the link of "Docs" in the footer from https://docs.stacks.co to https://docs.stacks.co/concepts/sbtc


doc.stacks.co refers to ongoing Nakamoto upgrade, lol

![image](https://github.com/user-attachments/assets/4cd821af-6e4d-46aa-94af-51223572652b)


## Type of Change
- documentation update

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Testing information
N/A

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @hozzjss 
