### PR TITLE
Updated wording deposit reclaim

### DIFF
--- a/src/comps/Deposit.tsx
+++ b/src/comps/Deposit.tsx
@@ -498,22 +498,20 @@ const DepositFlowReview = ({ txId }: DepositFlowReviewProps) => {
             To avoid losing your progress, please keep this page open.
           </SubText>
         </div>
-        {showDepositWarning && (
+        {bridgeConfig.LIVECHAT_ID && showDepositWarning && (
           <div className="flex flex-1 items-end">
             <SubText>
               There is a delay in processing your deposit, but signers are still
-              working on it and your funds are secure. Please contact our
-              support team
+              working on it and your funds are secure. Please contact our{" "}
               <a
                 target="_blank"
                 rel="noreferrer"
                 className="text-blue-500 underline"
                 href={`https://direct.lc.chat/${bridgeConfig.LIVECHAT_ID}/`}
               >
-                {"  "}
-                here{"  "}
-              </a>
-              to help us expedite it.”
+                support team here
+              </a>{" "}
+              to help us expedite it.
             </SubText>
           </div>
         )}

--- a/src/comps/Deposit.tsx
+++ b/src/comps/Deposit.tsx
@@ -472,6 +472,7 @@ const DepositFlowReview = ({ txId }: DepositFlowReviewProps) => {
       return elapsedBlocks >= 6;
     }
   }, [confirmedBlockHeight, currentBlockHeight]);
+  const bridgeConfig = useAtomValue(bridgeConfigAtom);
   return (
     <FlowContainer>
       <>
@@ -505,7 +506,7 @@ const DepositFlowReview = ({ txId }: DepositFlowReviewProps) => {
               support team
               <Link
                 className="text-blue-500 underline"
-                href="https://direct.lc.chat/18945692/"
+                href={`https://direct.lc.chat/${bridgeConfig.LIVECHAT_ID}/`}
               >
                 {"  "}
                 here{"  "}

--- a/src/comps/Deposit.tsx
+++ b/src/comps/Deposit.tsx
@@ -44,7 +44,7 @@ import { useQuery } from "@tanstack/react-query";
 import getBtcBalance from "@/actions/get-btc-balance";
 import { useDepositStatus } from "@/hooks/use-deposit-status";
 import { useEmilyDeposit } from "@/util/use-emily-deposit";
-import Link from "next/link";
+
 /*
   deposit flow has 3 steps
   1) enter amount you want to deposit

--- a/src/comps/Deposit.tsx
+++ b/src/comps/Deposit.tsx
@@ -463,16 +463,12 @@ const DepositFlowReview = ({ txId }: DepositFlowReviewProps) => {
     return (statusResponse?.vout[0].value || 0) / 1e8;
   }, [statusResponse?.vout]);
 
-  console.log("confirmedBlockHeight", confirmedBlockHeight);
-  console.log("currentBlockHeight", currentBlockHeight);
-
   const showDepositWarning = useMemo(() => {
     if (confirmedBlockHeight === 0) {
       return false;
     } else {
       const elapsedBlocks = currentBlockHeight - confirmedBlockHeight;
 
-      console.log("elapsedBlocks,", elapsedBlocks);
       return elapsedBlocks >= 6;
     }
   }, [confirmedBlockHeight, currentBlockHeight]);

--- a/src/comps/Deposit.tsx
+++ b/src/comps/Deposit.tsx
@@ -44,6 +44,7 @@ import { useQuery } from "@tanstack/react-query";
 import getBtcBalance from "@/actions/get-btc-balance";
 import { useDepositStatus } from "@/hooks/use-deposit-status";
 import { useEmilyDeposit } from "@/util/use-emily-deposit";
+import Link from "next/link";
 /*
   deposit flow has 3 steps
   1) enter amount you want to deposit
@@ -448,12 +449,33 @@ type DepositFlowReviewProps = DepositFlowStepProps & {
 };
 
 const DepositFlowReview = ({ txId }: DepositFlowReviewProps) => {
-  const { status, recipient, stacksTxId, statusResponse } =
-    useDepositStatus(txId);
+  const {
+    confirmedBlockHeight,
+    currentBlockHeight,
+    status,
+    recipient,
+    stacksTxId,
+    statusResponse,
+  } = useDepositStatus(txId);
+
   const { WALLET_NETWORK: walletNetwork } = useAtomValue(bridgeConfigAtom);
   const btcAmount = useMemo(() => {
     return (statusResponse?.vout[0].value || 0) / 1e8;
   }, [statusResponse?.vout]);
+
+  console.log("confirmedBlockHeight", confirmedBlockHeight);
+  console.log("currentBlockHeight", currentBlockHeight);
+
+  const showDepositWarning = useMemo(() => {
+    if (confirmedBlockHeight === 0) {
+      return false;
+    } else {
+      const elapsedBlocks = currentBlockHeight - confirmedBlockHeight;
+
+      console.log("elapsedBlocks,", elapsedBlocks);
+      return elapsedBlocks >= 6;
+    }
+  }, [confirmedBlockHeight, currentBlockHeight]);
   return (
     <FlowContainer>
       <>
@@ -479,6 +501,23 @@ const DepositFlowReview = ({ txId }: DepositFlowReviewProps) => {
             To avoid losing your progress, please keep this page open.
           </SubText>
         </div>
+        {showDepositWarning && (
+          <div className="flex flex-1 items-end">
+            <SubText>
+              There is a delay in processing your deposit, but signers are still
+              working on it and your funds are secure. Please contact our
+              support team
+              <Link
+                className="text-blue-500 underline"
+                href="https://direct.lc.chat/18945692/"
+              >
+                {"  "}
+                here{"  "}
+              </Link>
+              to help us expedite it.”
+            </SubText>
+          </div>
+        )}
         <div className="flex flex-1 items-end">
           <DepositStepper status={status} txId={txId} />
         </div>
@@ -487,7 +526,9 @@ const DepositFlowReview = ({ txId }: DepositFlowReviewProps) => {
           <div className="w-full flex-row flex justify-between items-center">
             <a
               className="w-40 rounded-lg py-3 flex justify-center items-center flex-row bg-orange"
-              href={`https://explorer.hiro.so/txid/${stacksTxId}?chain=${walletNetwork === "mainnet" ? "mainnet" : "testnet"}`}
+              href={`https://explorer.hiro.so/txid/${stacksTxId}?chain=${
+                walletNetwork === "mainnet" ? "mainnet" : "testnet"
+              }`}
               target="_blank"
               rel="noreferrer"
             >

--- a/src/comps/Deposit.tsx
+++ b/src/comps/Deposit.tsx
@@ -504,13 +504,15 @@ const DepositFlowReview = ({ txId }: DepositFlowReviewProps) => {
               There is a delay in processing your deposit, but signers are still
               working on it and your funds are secure. Please contact our
               support team
-              <Link
+              <a
+                target="_blank"
+                rel="noreferrer"
                 className="text-blue-500 underline"
                 href={`https://direct.lc.chat/${bridgeConfig.LIVECHAT_ID}/`}
               >
                 {"  "}
                 here{"  "}
-              </Link>
+              </a>
               to help us expedite it.”
             </SubText>
           </div>

--- a/src/comps/ReclaimManager.tsx
+++ b/src/comps/ReclaimManager.tsx
@@ -454,22 +454,23 @@ const ReclaimDeposit = ({
               {useShortAddress(getWalletAddress() || "")}
             </p>
           </div>
-          <div className="flex flex-1 items-end">
-            <SubText>
-              Please note that we have received reports of errors with Ledgers
-              running the reclaim function - if you are using a ledger and
-              experience this please contact our support team
-              <a
-                target="_blank"
-                rel="noreferrer"
-                className="text-blue-500 underline"
-                href={`https://direct.lc.chat/${LIVECHAT_ID}/`}
-              >
-                {"  "}
-                here{"  "}
-              </a>
-            </SubText>
-          </div>
+          {LIVECHAT_ID && (
+            <div className="flex flex-1 items-end">
+              <SubText>
+                Please note that we have received reports of errors with Ledgers
+                running the reclaim function - if you are using a ledger and
+                experience this please contact our{" "}
+                <a
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-blue-500 underline"
+                  href={`https://direct.lc.chat/${LIVECHAT_ID}/`}
+                >
+                  support team here
+                </a>
+              </SubText>
+            </div>
+          )}
         </div>
         <div className="flex flex-1 ">
           <div className="w-full p-4 bg-lightOrange h-20 rounded-lg flex flex-row items-center justify-center gap-2">

--- a/src/comps/ReclaimManager.tsx
+++ b/src/comps/ReclaimManager.tsx
@@ -30,6 +30,7 @@ import {
   signPSBTLeather,
   signPSBTXverse,
 } from "@/util/wallet-utils/src/sign-psbt";
+import Link from "next/link";
 
 /*
   Goal : User server side rendering as much as possible
@@ -452,6 +453,20 @@ const ReclaimDeposit = ({
             <p className="text-black font-Matter font-semibold text-sm">
               {useShortAddress(getWalletAddress() || "")}
             </p>
+          </div>
+          <div className="flex flex-1 items-end">
+            <SubText>
+              Please note that we have received reports of errors with Ledgers
+              running the reclaim function - if you are using a ledger and
+              experience this please contact our support team
+              <Link
+                className="text-blue-500 underline"
+                href="https://direct.lc.chat/18945692/"
+              >
+                {"  "}
+                here{"  "}
+              </Link>
+            </SubText>
           </div>
         </div>
         <div className="flex flex-1 ">

--- a/src/comps/ReclaimManager.tsx
+++ b/src/comps/ReclaimManager.tsx
@@ -331,7 +331,8 @@ const ReclaimDeposit = ({
   const setShowWallet = useSetAtom(showConnectWalletAtom);
   const router = useRouter();
 
-  const { WALLET_NETWORK: walletNetwork } = useAtomValue(bridgeConfigAtom);
+  const { WALLET_NETWORK: walletNetwork, LIVECHAT_ID } =
+    useAtomValue(bridgeConfigAtom);
 
   const buildReclaimTransaction = async () => {
     try {
@@ -461,7 +462,7 @@ const ReclaimDeposit = ({
               experience this please contact our support team
               <Link
                 className="text-blue-500 underline"
-                href="https://direct.lc.chat/18945692/"
+                href={`https://direct.lc.chat/${LIVECHAT_ID}/`}
               >
                 {"  "}
                 here{"  "}

--- a/src/comps/ReclaimManager.tsx
+++ b/src/comps/ReclaimManager.tsx
@@ -460,13 +460,15 @@ const ReclaimDeposit = ({
               Please note that we have received reports of errors with Ledgers
               running the reclaim function - if you are using a ledger and
               experience this please contact our support team
-              <Link
+              <a
+                target="_blank"
+                rel="noreferrer"
                 className="text-blue-500 underline"
                 href={`https://direct.lc.chat/${LIVECHAT_ID}/`}
               >
                 {"  "}
                 here{"  "}
-              </Link>
+              </a>
             </SubText>
           </div>
         </div>

--- a/src/comps/ReclaimManager.tsx
+++ b/src/comps/ReclaimManager.tsx
@@ -30,7 +30,6 @@ import {
   signPSBTLeather,
   signPSBTXverse,
 } from "@/util/wallet-utils/src/sign-psbt";
-import Link from "next/link";
 
 /*
   Goal : User server side rendering as much as possible

--- a/src/hooks/use-deposit-status.ts
+++ b/src/hooks/use-deposit-status.ts
@@ -31,6 +31,9 @@ export function useDepositStatus(txId: string) {
     ReturnType<typeof getRawTransaction>
   > | null>(null);
 
+  const [currentBlockHeight, setCurrentBlockHeight] = useState<number>(0);
+  const [confirmedBlockHeight, setConfirmedBlockHeight] = useState<number>(0);
+
   const { EMILY_URL: emilyUrl, RECLAIM_LOCK_TIME } =
     useAtomValue(bridgeConfigAtom);
 
@@ -54,6 +57,7 @@ export function useDepositStatus(txId: string) {
     ) {
       const check = async () => {
         const info = await getRawTransaction(txId);
+
         const txInfo = await getEmilyDepositInfo({
           txId,
           emilyURL: emilyUrl!,
@@ -72,6 +76,9 @@ export function useDepositStatus(txId: string) {
           return router.push(`/?txId=${rbfTxId}&step=3`);
         }
         setStatusResponse(info);
+
+        console.log("info", info);
+        console.log("txInfo", txInfo);
         if (info.status.confirmed) {
           setEmilyResponse(txInfo);
 
@@ -81,8 +88,14 @@ export function useDepositStatus(txId: string) {
             return;
           }
           const currentBlockHeight = await getCurrentBlockHeight();
+
+          setCurrentBlockHeight(currentBlockHeight);
+
+          const confirmedBlockTime = info.status.block_height || 0;
+          setConfirmedBlockHeight(confirmedBlockTime);
           const unlockBlock =
             Number(RECLAIM_LOCK_TIME || 144) + info.status.block_height - 1;
+
           const isPastLockTime = currentBlockHeight >= unlockBlock;
           if (isPastLockTime) {
             setTransferTxStatus(DepositStatus.Failed);
@@ -111,5 +124,7 @@ export function useDepositStatus(txId: string) {
     recipient: recipient && (Cl.deserialize(recipient) as PrincipalCV).value,
     stacksTxId: stacksTxId,
     statusResponse,
+    currentBlockHeight,
+    confirmedBlockHeight,
   };
 }

--- a/src/hooks/use-deposit-status.ts
+++ b/src/hooks/use-deposit-status.ts
@@ -77,8 +77,6 @@ export function useDepositStatus(txId: string) {
         }
         setStatusResponse(info);
 
-        console.log("info", info);
-        console.log("txInfo", txInfo);
         if (info.status.confirmed) {
           setEmilyResponse(txInfo);
 

--- a/src/hooks/use-deposit-status.ts
+++ b/src/hooks/use-deposit-status.ts
@@ -32,8 +32,10 @@ export function useDepositStatus(txId: string) {
   > | null>(null);
 
   const [currentBlockHeight, setCurrentBlockHeight] = useState<number>(0);
-  const [confirmedBlockHeight, setConfirmedBlockHeight] = useState<number>(0);
 
+  const confirmedBlockHeight = useMemo(() => {
+    return statusResponse?.status.block_height || 0;
+  }, [statusResponse]);
   const { EMILY_URL: emilyUrl, RECLAIM_LOCK_TIME } =
     useAtomValue(bridgeConfigAtom);
 
@@ -89,8 +91,6 @@ export function useDepositStatus(txId: string) {
 
           setCurrentBlockHeight(currentBlockHeight);
 
-          const confirmedBlockTime = info.status.block_height || 0;
-          setConfirmedBlockHeight(confirmedBlockTime);
           const unlockBlock =
             Number(RECLAIM_LOCK_TIME || 144) + info.status.block_height - 1;
 


### PR DESCRIPTION
Text updates for the reclaim:

On the "Deposit - processing" page
After 6 blocks, if a deposit hasn't cleared, add language that says
There is a delay in processing your deposit, but signers are still working on it and your funds are secure. Please contact our support team here to help us expedite it.

<img width="828" alt="image" src="https://github.com/user-attachments/assets/aac69579-d5a1-4e28-a427-13efe5d8ba4d" />


2. On the "Reclaim" page
On the reclaim page itself add additional language that says:
Please note that we have received reports of errors with Ledgers running the reclaim function - if you are using a ledger and experience this please contact our support team here

<img width="828" alt="image" src="https://github.com/user-attachments/assets/0a62764e-14fc-48d8-ab58-3bcb25354743" />
