### PR TITLE
Be pessimistic with limits from Emily

### DIFF
--- a/src/actions/get-emily-limits.ts
+++ b/src/actions/get-emily-limits.ts
@@ -24,6 +24,7 @@ export default async function getEmilyLimits() {
   const json = (await res.json()) as EmilyLimits;
   // exclude account caps
   return {
+    // if null, it means unlimited
     pegCap: json.pegCap || Infinity,
     perDepositCap: json.perDepositCap || Infinity,
     perWithdrawalCap: json.perWithdrawalCap || Infinity,

--- a/src/actions/get-emily-limits.ts
+++ b/src/actions/get-emily-limits.ts
@@ -16,10 +16,9 @@ export default async function getEmilyLimits() {
   const json = (await res.json()) as EmilyLimits;
   // exclude account caps
   return {
-    // if null, it means unlimited
-    pegCap: json.pegCap || Infinity,
-    perDepositCap: json.perDepositCap || Infinity,
-    perWithdrawalCap: json.perWithdrawalCap || Infinity,
-    perDepositMinimum: json.perDepositMinimum || 0,
+    pegCap: json.pegCap || 0,
+    perDepositCap: json.perDepositCap || 0,
+    perWithdrawalCap: json.perWithdrawalCap || 0,
+    perDepositMinimum: json.perDepositMinimum || Infinity,
   };
 }

--- a/src/actions/get-emily-limits.ts
+++ b/src/actions/get-emily-limits.ts
@@ -13,12 +13,20 @@ type AccountCaps = {};
 
 export default async function getEmilyLimits() {
   const res = await fetch(`${env.EMILY_URL}/limits`);
+  if (!res.ok) {
+    return {
+      pegCap: 0,
+      perDepositCap: 0,
+      perWithdrawalCap: 0,
+      perDepositMinimum: Infinity,
+    };
+  }
   const json = (await res.json()) as EmilyLimits;
   // exclude account caps
   return {
-    pegCap: json.pegCap || 0,
-    perDepositCap: json.perDepositCap || 0,
-    perWithdrawalCap: json.perWithdrawalCap || 0,
-    perDepositMinimum: json.perDepositMinimum || Infinity,
+    pegCap: json.pegCap || Infinity,
+    perDepositCap: json.perDepositCap || Infinity,
+    perWithdrawalCap: json.perWithdrawalCap || Infinity,
+    perDepositMinimum: json.perDepositMinimum || 0,
   };
 }


### PR DESCRIPTION
In case Emily is down, the bridge will assume that limits are unset and let deposits go through. This is confusing for users.

This PR puts a band-aid to this problem, by assuming the worst (so very restrictive limits) if Emily doesn't answer.

This is still not good enough though, since the bridge needs to be able to tell:

1. Whether Emily is down;
2. whether the limits are `null` and thus there are no limits.

Those are two different use cases which are not currently handled correctly. I'll open an issue about it.