### PR TITLE
feat: Add GIT_COMMIT version in the building phase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM node:18 AS builder
 
 WORKDIR /code
 
+# docker build --build-arg GIT_COMMIT=$(git rev-parse HEAD)
+ARG GIT_COMMIT
+ENV GIT_COMMIT=$GIT_COMMIT
+
 COPY package.json ./
 COPY yarn.lock ./
 RUN yarn install --frozen-lockfile
@@ -14,6 +18,10 @@ RUN npm run build
 FROM node:18
 
 WORKDIR /app
+
+ARG GIT_COMMIT
+ENV GIT_COMMIT=$GIT_COMMIT
+
 COPY --from=builder /code/node_modules ./node_modules
 COPY --from=builder /code/public ./public
 COPY --from=builder /code/.next ./.next

--- a/README.md
+++ b/README.md
@@ -34,3 +34,25 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Git commit ID for health endpoint
+
+To push the Git Commit version during the building phase you have to build the image passing the $GIT_COMMIT value:
+
+```bash
+export GIT_COMMIT=$(git rev-parse HEAD)
+
+docker build --build-arg GIT_COMMIT=$GIT_COMMIT
+```
+
+or passing through the docker compose file:
+
+```yaml
+sbtc-bridge:
+    restart: on-failure
+    build:
+      context: ./sbtc-bridge
+      dockerfile: Dockerfile
+      args:
+        GIT_COMMIT: ${GIT_COMMIT}
+```


### PR DESCRIPTION
Add the GIT_COMMIT version in the building phase

## Description

- Add GIT_COMMIT as ARGS 
- Add readme examples

## Testing information

Tested in the devnet

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `npm run test` passes
- [ ] Changelog is updated
