### PR TITLE
add feature flags

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -13,3 +13,6 @@ SUPPORT_LINK=
 POLLING_INTERVAL=5000
 BRIDGE_APP_URL=https://app.stacks.co
 STACKS_API_URL=https://api.hiro.so
+# comma separated values style
+# withdrawals,reskin
+FEATURE_FLAGS=

--- a/next.config.js
+++ b/next.config.js
@@ -26,7 +26,7 @@ const nextConfig = {
           ]
         : [];
 
-    redirects = !process.env.FEATURE_FLAGS.includes("withdrawals")
+    redirects = !process.env.FEATURE_FLAGS?.includes("withdrawals")
       ? [
           ...redirects,
           {
@@ -36,7 +36,7 @@ const nextConfig = {
           },
         ]
       : redirects;
-    redirects = !process.env.FEATURE_FLAGS.includes("reskin")
+    redirects = !process.env.FEATURE_FLAGS?.includes("reskin")
       ? [
           ...redirects,
           {

--- a/next.config.js
+++ b/next.config.js
@@ -26,17 +26,26 @@ const nextConfig = {
           ]
         : [];
 
-    redirects =
-      process.env.WALLET_NETWORK === "mainnet"
-        ? [
-            ...redirects,
-            {
-              source: "/withdraw",
-              destination: "/",
-              permanent: false,
-            },
-          ]
-        : redirects;
+    redirects = !process.env.FEATURE_FLAGS.includes("withdrawals")
+      ? [
+          ...redirects,
+          {
+            source: "/withdraw",
+            destination: "/",
+            permanent: false,
+          },
+        ]
+      : redirects;
+    redirects = !process.env.FEATURE_FLAGS.includes("reskin")
+      ? [
+          ...redirects,
+          {
+            source: "/reskin",
+            destination: "/",
+            permanent: false,
+          },
+        ]
+      : redirects;
     return redirects;
   },
   async headers() {

--- a/src/actions/get-sbtc-bridge-config.ts
+++ b/src/actions/get-sbtc-bridge-config.ts
@@ -16,6 +16,7 @@ export default cache(async function getSbtcBridgeConfig() {
   const MEMPOOL_API_URL = env.MEMPOOL_API_URL;
   const SUPPORT_LINK = env.SUPPORT_LINK;
   const POLLING_INTERVAL = env.POLLING_INTERVAL;
+  const FEATURE_FLAGS = env.FEATURE_FLAGS;
 
   return {
     EMILY_URL,
@@ -27,5 +28,6 @@ export default cache(async function getSbtcBridgeConfig() {
     SUPPORT_LINK,
     POLLING_INTERVAL,
     MEMPOOL_API_URL,
+    FEATURE_FLAGS,
   };
 });

--- a/src/comps/Header.tsx
+++ b/src/comps/Header.tsx
@@ -101,7 +101,7 @@ const Header = ({ config }: { config: BridgeConfig }) => {
             {/* <h5 className="font-Matter text-xs text-black tracking-wide ">
               LEARN MORE
             </h5> */}
-            {isConnected && config.WALLET_NETWORK !== "mainnet" && (
+            {isConnected && config.FEATURE_FLAGS.includes("withdrawals") && (
               <Link href="/withdraw" className="text-xs text-black underline">
                 Withdraw
               </Link>

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,6 +1,9 @@
 // MUST NOT BE USED BY CLIENT
 import "server-only";
 import { DefaultNetworkConfigurations } from "@leather.io/models";
+
+type featureFlag = "withdrawals" | "reskin";
+
 export const env = {
   BITCOIND_URL: process.env.BITCOIND_URL || "http://localhost:18443",
   EMILY_URL: process.env.EMILY_URL,
@@ -23,4 +26,5 @@ export const env = {
   POLLING_INTERVAL: Number(process.env.POLLING_INTERVAL) || 5000,
   BRIDGE_APP_URL: process.env.BRIDGE_APP_URL || "http://localhost:3000",
   STACKS_API_URL: process.env.STACKS_API_URL || "http://localhost:3999",
+  FEATURE_FLAGS: (process.env.FEATURE_FLAGS?.split(",") || []) as featureFlag[],
 };

--- a/src/util/atoms.ts
+++ b/src/util/atoms.ts
@@ -20,6 +20,7 @@ export const bridgeConfigAtom = atom<BridgeConfig>({
   SUPPORT_LINK: undefined,
   POLLING_INTERVAL: 5000,
   MEMPOOL_API_URL: "",
+  FEATURE_FLAGS: [],
 });
 export const depositMaxFeeAtom = atom(80000);
 


### PR DESCRIPTION
This is a simple PR just to make sure when pushing the v1 withdrawals the reskin isn't shipped with it. 

introducing a new env var
```sh
FEATURE_FLAGS=
```
should be a comma separated values list with the enabled features this only encompasses new withdrawals and reskin features in the withdrawals release at the 26th we'll need it to be set to 
```sh
FEATURE_FLAGS=withdrawals
```

@fabergat 
