### PR TITLE
remove taproot key references in wallet

### DIFF
--- a/src/app/reskin/components/header/connect-button.tsx
+++ b/src/app/reskin/components/header/connect-button.tsx
@@ -23,7 +23,6 @@ export const ConnectButton = () => {
       selectedWallet: null,
       addresses: {
         payment: null,
-        taproot: null,
         stacks: null,
         musig: null,
       },

--- a/src/comps/Header.tsx
+++ b/src/comps/Header.tsx
@@ -37,7 +37,6 @@ const Header = ({ config }: { config: BridgeConfig }) => {
       selectedWallet: null,
       addresses: {
         payment: null,
-        taproot: null,
         stacks: null,
         musig: null,
       },

--- a/src/util/atoms.ts
+++ b/src/util/atoms.ts
@@ -46,7 +46,6 @@ export const walletInfoAtom = atomWithStorage<{
   addresses: {
     // can't call this p2wpkh because xverse sometimes uses segwit rather than native segwit
     payment: Address | null;
-    taproot: Address | null;
     stacks: Address | null;
     musig: {
       users: AsignaUser[];
@@ -57,7 +56,6 @@ export const walletInfoAtom = atomWithStorage<{
   selectedWallet: null,
   addresses: {
     payment: null,
-    taproot: null,
     stacks: null,
     musig: null,
   },

--- a/src/util/wallet-utils/src/getAddress.ts
+++ b/src/util/wallet-utils/src/getAddress.ts
@@ -13,11 +13,6 @@ type Results = {
     address: string;
     publicKey: string;
   };
-  /** @description taproot address */
-  taproot: {
-    address: string;
-    publicKey: string;
-  };
   /** @description stacks address */
   stacks: {
     address: string;
@@ -52,10 +47,6 @@ const getAddressByPurpose = (
 export function getWalletAddresses(
   response: RpcSuccessResponse<"wallet_connect">["result"],
 ) {
-  const taproot = getAddressByPurpose(response, AddressPurpose.Ordinals);
-  // if (!taproot) {
-  //   throw new Error("Taproot address not found");
-  // }
   const payment = getAddressByPurpose(response, AddressPurpose.Payment);
   if (!payment) {
     throw new Error("Payment address not found");
@@ -66,10 +57,6 @@ export function getWalletAddresses(
   //   throw new Error("Stacks address not found");
   // }
   return {
-    taproot: {
-      address: taproot?.address || "",
-      publicKey: taproot?.publicKey || "",
-    },
     payment: {
       address: payment.address,
       publicKey: payment.publicKey,
@@ -130,10 +117,6 @@ export const getAddressesAsigna: getAddresses = async (params) => {
   }
   const response = await params.action();
   return {
-    taproot: {
-      address: "",
-      publicKey: "",
-    },
     payment: {
       address: response.address,
       publicKey: response.publicKey,
@@ -176,7 +159,6 @@ export const getAddressesLeather: getAddresses = async () => {
 
   const { addresses } = response.result;
   const payment = extractAddressByType(addresses, "p2wpkh")!;
-  const taproot = extractAddressByType(addresses, "p2tr")!;
   const stacks = addresses.find((address) => address.symbol === "STX");
   if (!stacks) {
     throw new Error(
@@ -185,7 +167,6 @@ export const getAddressesLeather: getAddresses = async () => {
   }
   return {
     payment,
-    taproot,
     stacks,
     musig: null,
   };


### PR DESCRIPTION
This step is to ensure that we have the payment address whether that is taproot or segwit to pay for deposits and the stacks address to sign the withdrawal transactions

@matteojug 