### PR TITLE
Make the set connected btc or stx addresses optional

### DIFF
--- a/src/comps/ConnectWallet.tsx
+++ b/src/comps/ConnectWallet.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/util/wallet-utils/src/getAddress";
 import { useAsignaConnect } from "@asigna/btc-connect";
 import { AddressVersion, createAddress } from "@stacks/transactions";
+import { getAddressInfo, Network } from "bitcoin-address-validation";
 
 const WALLET_PROVIDERS = [
   {
@@ -51,16 +52,15 @@ const WALLET_PROVIDERS = [
 ];
 
 const isMainnetWallet = (addresses: Awaited<ReturnType<getAddresses>>) => {
-  const isBitcoinMainnetAddress =
-    addresses.payment?.address?.startsWith("bc1") ||
-    addresses.payment?.address?.startsWith("3");
-  if (isBitcoinMainnetAddress !== undefined) {
-    return isBitcoinMainnetAddress;
-  }
-  const address = addresses.stacks?.address;
+  const bitcoinAddress = addresses.payment?.address;
+  const stacksAddress = addresses.stacks?.address;
 
-  if (address) {
-    const addressData = createAddress(address);
+  if (bitcoinAddress) {
+    return getAddressInfo(bitcoinAddress).network === Network.mainnet;
+  }
+
+  if (stacksAddress) {
+    const addressData = createAddress(stacksAddress);
     return (
       addressData.version === AddressVersion.MainnetMultiSig ||
       addressData.version === AddressVersion.MainnetSingleSig

--- a/src/util/wallet-utils/src/getAddress.ts
+++ b/src/util/wallet-utils/src/getAddress.ts
@@ -12,12 +12,12 @@ type Results = {
   payment: {
     address: string;
     publicKey: string;
-  };
+  } | null;
   /** @description stacks address */
   stacks: {
     address: string;
     publicKey: string;
-  };
+  } | null;
   musig: {
     users: AsignaUser[];
     threshold: number;
@@ -48,23 +48,10 @@ export function getWalletAddresses(
   response: RpcSuccessResponse<"wallet_connect">["result"],
 ) {
   const payment = getAddressByPurpose(response, AddressPurpose.Payment);
-  if (!payment) {
-    throw new Error("Payment address not found");
-  }
-
   const stacks = getAddressByPurpose(response, AddressPurpose.Stacks);
-  // if (!stacks) {
-  //   throw new Error("Stacks address not found");
-  // }
   return {
-    payment: {
-      address: payment.address,
-      publicKey: payment.publicKey,
-    },
-    stacks: {
-      address: stacks?.address || "",
-      publicKey: stacks?.publicKey || "",
-    },
+    payment: payment || null,
+    stacks: stacks || null,
     musig: null,
   };
 }
@@ -121,10 +108,7 @@ export const getAddressesAsigna: getAddresses = async (params) => {
       address: response.address,
       publicKey: response.publicKey,
     },
-    stacks: {
-      address: "",
-      publicKey: "",
-    },
+    stacks: null,
     musig: {
       users: response.users,
       threshold: response.threshold,
@@ -139,15 +123,8 @@ const extractAddressByType = (
   const addressInfo = addresses.find(
     (address) => address.symbol === "BTC" && address.type === addressType,
   );
-  if (!addressInfo) {
-    throw new Error(
-      "BTC address not found, please make sure to connect your bitcoin wallet on leather and try again",
-    );
-  }
-  return {
-    address: addressInfo.address,
-    publicKey: addressInfo.publicKey,
-  };
+
+  return addressInfo || null;
 };
 /**
  * @name getAddressesLeather
@@ -158,16 +135,12 @@ export const getAddressesLeather: getAddresses = async () => {
   const response = await btc.request("getAddresses");
 
   const { addresses } = response.result;
-  const payment = extractAddressByType(addresses, "p2wpkh")!;
+  const payment = extractAddressByType(addresses, "p2wpkh");
   const stacks = addresses.find((address) => address.symbol === "STX");
-  if (!stacks) {
-    throw new Error(
-      "No STX address found, please make sure to connect your stacks wallet on leather and try again",
-    );
-  }
+
   return {
-    payment,
-    stacks,
+    payment: payment || null,
+    stacks: stacks || null,
     musig: null,
   };
 };


### PR DESCRIPTION
This also enforces having at least one but not the other to mark the user connected This would mean that consumers of that state request it explicitly if it's not found
