### PR TITLE
less dependence on hiro api to get withdrawal status

### DIFF
--- a/src/actions/get-emily-withdrawal.ts
+++ b/src/actions/get-emily-withdrawal.ts
@@ -43,8 +43,9 @@ export async function getEmilyWithdrawal(requestId: string) {
   if (!withdrawal.ok) {
     throw new Error(`Failed to fetch withdrawal data: ${withdrawal.status}`);
   }
-  const { status, amount, recipient } =
-    (await withdrawal.json()) as EmilyWithdrawal;
+  const data = await withdrawal.json();
+
+  const { status, amount, recipient, fulfillment } = data as EmilyWithdrawal;
   const bitcoinNetwork = getBitcoinNetwork(env.WALLET_NETWORK);
   return {
     address: bitcoin.address.fromOutputScript(
@@ -54,5 +55,7 @@ export async function getEmilyWithdrawal(requestId: string) {
     amount: amount,
     status: WithdrawalStatus[status as WithdrawalStatus],
     requestId,
+    stacksTx: fulfillment?.StacksTxid,
+    bitcoinTx: fulfillment?.BitcoinTxid,
   };
 }

--- a/src/actions/get-emily-withdrawal.ts
+++ b/src/actions/get-emily-withdrawal.ts
@@ -1,0 +1,58 @@
+"use server";
+
+import { env } from "@/env";
+import getBitcoinNetwork from "@/util/get-bitcoin-network";
+import * as bitcoin from "bitcoinjs-lib";
+import { hexToBytes } from "@stacks/common";
+import ecc from "@bitcoinerlab/secp256k1";
+import { WithdrawalStatus } from "@/app/withdraw/[txid]/components/util";
+
+bitcoin.initEccLib(ecc);
+
+type EmilyWithdrawal = {
+  requestId: number;
+  stacksBlockHash: string;
+  stacksBlockHeight: number;
+  recipient: string;
+  sender: string;
+  amount: number;
+  lastUpdateHeight: number;
+  lastUpdateBlockHash: string;
+  status: string;
+  statusMessage: string;
+  parameters: Parameters;
+  fulfillment?: Fulfillment;
+};
+
+type Parameters = {
+  maxFee: number;
+};
+
+type Fulfillment = {
+  BitcoinTxid: string;
+  BitcoinTxIndex: number;
+  StacksTxid: string;
+  BitcoinBlockHash: string;
+  BitcoinBlockHeight: number;
+  BtcFee: number;
+};
+
+export async function getEmilyWithdrawal(requestId: string) {
+  const withdrawal = await fetch(`${env.EMILY_URL}/withdrawal/${requestId}`);
+
+  if (!withdrawal.ok) {
+    throw new Error(`Failed to fetch withdrawal data: ${withdrawal.status}`);
+  }
+  const { status, amount, recipient } =
+    (await withdrawal.json()) as EmilyWithdrawal;
+  const bitcoinNetwork = getBitcoinNetwork(env.WALLET_NETWORK);
+  return {
+    address: bitcoin.address.fromOutputScript(
+      hexToBytes(recipient),
+      bitcoinNetwork,
+    ),
+    amount: amount,
+    status: WithdrawalStatus[status as WithdrawalStatus],
+    requestId,
+  };
+}

--- a/src/actions/get-registry-withdrawal.ts
+++ b/src/actions/get-registry-withdrawal.ts
@@ -1,0 +1,72 @@
+"use server";
+
+import { env } from "@/env";
+import {
+  BooleanCV,
+  BufferCV,
+  Cl,
+  ClarityType,
+  fetchCallReadOnlyFunction,
+  OptionalCV,
+  PrincipalCV,
+  TupleCV,
+  UIntCV,
+} from "@stacks/transactions";
+import { hiroClient } from "./hiro-fetch";
+import { getStacksNetwork } from "@/util/get-stacks-network";
+import { WithdrawalStatus } from "@/app/withdraw/[txid]/components/util";
+import getBitcoinNetwork from "@/util/get-bitcoin-network";
+import { encodeBitcoinAddress } from "@/util/decode-bitcoin-address";
+
+type RegistryWithdrawal = OptionalCV<
+  TupleCV<{
+    amount: UIntCV;
+    "block-height": UIntCV;
+    "max-fee": UIntCV;
+    recipient: TupleCV<{
+      hashbytes: BufferCV;
+      version: BufferCV;
+    }>;
+    sender: PrincipalCV;
+    status: OptionalCV<BooleanCV>;
+  }>
+>;
+
+export async function getRegistryWithdrawal(id: string) {
+  const res = (await fetchCallReadOnlyFunction({
+    contractAddress: env.SBTC_CONTRACT_DEPLOYER!,
+    contractName: "sbtc-registry",
+    functionName: "get-withdrawal-request",
+    functionArgs: [Cl.uint(id)],
+    network: getStacksNetwork(env.WALLET_NETWORK),
+    senderAddress: env.SBTC_CONTRACT_DEPLOYER!,
+    client: hiroClient,
+  })) as RegistryWithdrawal;
+
+  if (res.type === ClarityType.OptionalNone) {
+    throw new Error("Withdrawal not found");
+  }
+  const _status = res.value.value.status;
+  let status = WithdrawalStatus.pending;
+
+  if (_status.type === ClarityType.OptionalSome) {
+    const isSuccessful = _status.value.type === ClarityType.BoolTrue;
+    status = isSuccessful
+      ? WithdrawalStatus.confirmed
+      : WithdrawalStatus.failed;
+  }
+
+  const recipient = res.value.value.recipient.value;
+
+  const address = encodeBitcoinAddress(
+    recipient.hashbytes.value,
+    recipient.version.value,
+    getBitcoinNetwork(env.WALLET_NETWORK),
+  );
+  return {
+    status,
+    address,
+    amount: Number(res.value.value.amount.value),
+    requestId: id,
+  };
+}

--- a/src/actions/get-withdrawal-data.ts
+++ b/src/actions/get-withdrawal-data.ts
@@ -10,6 +10,7 @@ import getBitcoinNetwork from "@/util/get-bitcoin-network";
 import { hiroClient } from "./hiro-fetch";
 
 import { getEmilyWithdrawal } from "./get-emily-withdrawal";
+import { getRegistryWithdrawal } from "./get-registry-withdrawal";
 
 type contractCallData = {
   contract_id: string;
@@ -34,7 +35,16 @@ export async function getWithdrawalInfo(txidOrRequestId: string): Promise<{
   const isRequestId = txidOrRequestId.length < 64;
 
   if (isRequestId) {
-    return await getEmilyWithdrawal(txidOrRequestId);
+    try {
+      return getEmilyWithdrawal(txidOrRequestId);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "error fetching emily withdrawal falling back to registry",
+        // e,
+      );
+      return getRegistryWithdrawal(txidOrRequestId);
+    }
   }
 
   const tx = await hiroClient.fetch(

--- a/src/actions/get-withdrawal-data.ts
+++ b/src/actions/get-withdrawal-data.ts
@@ -31,6 +31,8 @@ export async function getWithdrawalInfo(txidOrRequestId: string): Promise<{
   address: string;
   requestId: string | null;
   amount: number;
+  stacksTx?: string;
+  bitcoinTx?: string;
 }> {
   const isRequestId = txidOrRequestId.length < 64;
 

--- a/src/app/withdraw/[txid]/components/withdrawal-status.tsx
+++ b/src/app/withdraw/[txid]/components/withdrawal-status.tsx
@@ -12,6 +12,7 @@ import LandingAnimation from "@/comps/core/LandingAnimation";
 import { useQuery } from "@tanstack/react-query";
 import { getWithdrawalInfo } from "@/actions/get-withdrawal-data";
 import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 const { useStepper, Scoped } = withdrawalStepper;
 type Props = {
@@ -40,7 +41,7 @@ export default function TrackWithdrawalStatus(props: Props) {
 function Content(initialData: Props) {
   const { txid } = initialData;
   const {
-    data: { address, amount, status },
+    data: { address, amount, status, requestId },
   } = useQuery({
     queryKey: ["withdrawal", txid],
     queryFn: async () => {
@@ -51,6 +52,7 @@ function Content(initialData: Props) {
       status: initialData.status,
       address: initialData.recipient,
       amount: initialData.btcAmount,
+      requestId: null,
     },
     refetchInterval: ({ state }) => {
       const status = state.data?.status;
@@ -63,6 +65,20 @@ function Content(initialData: Props) {
       return 5000;
     },
   });
+
+  const router = useRouter();
+
+  useEffect(() => {
+    // if the route is request id format do nothing
+    if (txid.length < 64) {
+      return;
+    }
+
+    // if it is a tx id and we have a request id navigate to request id
+    if (requestId) {
+      router.push(`/withdraw/${requestId}`);
+    }
+  }, [requestId, router, txid.length]);
   const stepper = useStepper();
 
   useEffect(() => {

--- a/src/app/withdraw/[txid]/components/withdrawal-status.tsx
+++ b/src/app/withdraw/[txid]/components/withdrawal-status.tsx
@@ -45,7 +45,7 @@ function Content(initialData: Props) {
   const { txid } = initialData;
 
   const {
-    data: { address, amount, status, stacksTx, bitcoinTx },
+    data: { address, amount, status, bitcoinTx },
   } = useQuery({
     queryKey: ["withdrawal", txid],
     queryFn: async () => {
@@ -123,19 +123,18 @@ function Content(initialData: Props) {
       </div>
 
       <div className="w-full flex-row flex justify-between items-center">
-        {stacksTx && (
-          <a
-            className="w-40 rounded-lg py-3 flex justify-center items-center flex-row bg-orange"
-            href={getExplorerUrl(
-              stacksTx,
-              getStacksNetwork(bridgeConfig.WALLET_NETWORK),
-            )}
-            target="_blank"
-            rel="noreferrer"
-          >
-            View stacks tx
-          </a>
-        )}
+        <a
+          className="w-40 rounded-lg py-3 flex justify-center items-center flex-row bg-orange"
+          href={getExplorerUrl(
+            txid,
+            getStacksNetwork(bridgeConfig.WALLET_NETWORK),
+          )}
+          target="_blank"
+          rel="noreferrer"
+        >
+          View stacks tx
+        </a>
+
         {bitcoinTx && (
           <a
             className="w-40 rounded-lg py-3 flex justify-center items-center flex-row bg-orange"

--- a/src/app/withdraw/[txid]/components/withdrawal-status.tsx
+++ b/src/app/withdraw/[txid]/components/withdrawal-status.tsx
@@ -12,7 +12,6 @@ import LandingAnimation from "@/comps/core/LandingAnimation";
 import { useQuery } from "@tanstack/react-query";
 import { getWithdrawalInfo } from "@/actions/get-withdrawal-data";
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
 import { getExplorerUrl } from "@/lib/get-explorer-url";
 import { getStacksNetwork } from "@/util/get-stacks-network";
 
@@ -46,7 +45,7 @@ function Content(initialData: Props) {
   const { txid } = initialData;
 
   const {
-    data: { address, amount, status, requestId, stacksTx, bitcoinTx },
+    data: { address, amount, status, stacksTx, bitcoinTx },
   } = useQuery({
     queryKey: ["withdrawal", txid],
     queryFn: async () => {
@@ -73,19 +72,6 @@ function Content(initialData: Props) {
     },
   });
 
-  const router = useRouter();
-
-  useEffect(() => {
-    // if the route is request id format do nothing
-    if (txid.length < 64) {
-      return;
-    }
-
-    // if it is a tx id and we have a request id navigate to request id
-    if (requestId) {
-      router.push(`/withdraw/${requestId}`);
-    }
-  }, [requestId, router, txid.length]);
   const stepper = useStepper();
 
   useEffect(() => {

--- a/src/app/withdraw/[txid]/components/withdrawal-status.tsx
+++ b/src/app/withdraw/[txid]/components/withdrawal-status.tsx
@@ -13,6 +13,8 @@ import { useQuery } from "@tanstack/react-query";
 import { getWithdrawalInfo } from "@/actions/get-withdrawal-data";
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { getExplorerUrl } from "@/lib/get-explorer-url";
+import { getStacksNetwork } from "@/util/get-stacks-network";
 
 const { useStepper, Scoped } = withdrawalStepper;
 type Props = {
@@ -20,6 +22,8 @@ type Props = {
   recipient: string;
   txid: string;
   status: WithdrawalStatus;
+  stacksTx?: string;
+  bitcoinTx?: string;
 };
 export default function TrackWithdrawalStatus(props: Props) {
   return (
@@ -40,8 +44,9 @@ export default function TrackWithdrawalStatus(props: Props) {
 
 function Content(initialData: Props) {
   const { txid } = initialData;
+
   const {
-    data: { address, amount, status, requestId },
+    data: { address, amount, status, requestId, stacksTx, bitcoinTx },
   } = useQuery({
     queryKey: ["withdrawal", txid],
     queryFn: async () => {
@@ -52,6 +57,8 @@ function Content(initialData: Props) {
       status: initialData.status,
       address: initialData.recipient,
       amount: initialData.btcAmount,
+      stacksTx: initialData.stacksTx,
+      bitcoinTx: initialData.bitcoinTx,
       requestId: null,
     },
     refetchInterval: ({ state }) => {
@@ -129,20 +136,31 @@ function Content(initialData: Props) {
         <WithdrawalStepper status={status} txId={txid} />
       </div>
 
-      {txid && (
-        <div className="w-full flex-row flex justify-between items-center">
+      <div className="w-full flex-row flex justify-between items-center">
+        {stacksTx && (
           <a
             className="w-40 rounded-lg py-3 flex justify-center items-center flex-row bg-orange"
-            href={`https://explorer.hiro.so/txid/${txid}?chain=${
-              bridgeConfig.WALLET_NETWORK === "mainnet" ? "mainnet" : "testnet"
-            }`}
+            href={getExplorerUrl(
+              stacksTx,
+              getStacksNetwork(bridgeConfig.WALLET_NETWORK),
+            )}
             target="_blank"
             rel="noreferrer"
           >
             View stacks tx
           </a>
-        </div>
-      )}
+        )}
+        {bitcoinTx && (
+          <a
+            className="w-40 rounded-lg py-3 flex justify-center items-center flex-row bg-orange"
+            href={`${bridgeConfig.PUBLIC_MEMPOOL_URL}/tx/${bitcoinTx}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            View bitcoin tx
+          </a>
+        )}
+      </div>
     </FlowContainer>
   );
 }

--- a/src/app/withdraw/[txid]/error.tsx
+++ b/src/app/withdraw/[txid]/error.tsx
@@ -1,0 +1,52 @@
+"use client";
+import LandingAnimation from "@/comps/core/LandingAnimation";
+import { FlowContainer } from "@/comps/core/FlowContainer";
+import { Heading, SubText } from "@/comps/core/Heading";
+import { PrimaryButton } from "@/comps/core/FlowButtons";
+import OldLayoutClient from "@/app/old-layout-client";
+import getSbtcBridgeConfig from "@/actions/get-sbtc-bridge-config";
+
+import { useEffect, useState } from "react";
+import { BridgeConfig } from "@/util/atoms";
+
+export default function WithdrawalStatusPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const [config, setConfig] = useState<BridgeConfig | null>(null);
+
+  useEffect(() => {
+    getSbtcBridgeConfig().then(setConfig);
+  }, []);
+
+  return (
+    config && (
+      <OldLayoutClient config={config}>
+        <LandingAnimation>
+          <div className="w-screen flex"></div>
+          <FlowContainer>
+            <div className="w-full flex flex-row items-center justify-between">
+              <Heading>Error fetching transaction status</Heading>
+            </div>
+
+            <div className="flex flex-1 items-end">
+              <SubText>Click the button below to try again.</SubText>
+            </div>
+
+            <div className="flex flex-1 items-end">
+              <PrimaryButton onClick={reset}>Try Again</PrimaryButton>
+            </div>
+          </FlowContainer>
+          <div
+            style={{
+              margin: "16px 0",
+            }}
+          />
+        </LandingAnimation>
+      </OldLayoutClient>
+    )
+  );
+}

--- a/src/app/withdraw/[txid]/page.tsx
+++ b/src/app/withdraw/[txid]/page.tsx
@@ -17,6 +17,8 @@ export default async function WithdrawalStatusPage({
       <TrackWithdrawalStatus
         status={result.status}
         txid={txid}
+        stacksTx={result.stacksTx}
+        bitcoinTx={result.bitcoinTx}
         btcAmount={result.amount}
         recipient={result.address}
       />

--- a/src/comps/Deposit.tsx
+++ b/src/comps/Deposit.tsx
@@ -46,6 +46,8 @@ import getBtcBalance from "@/actions/get-btc-balance";
 import { useDepositStatus } from "@/hooks/use-deposit-status";
 import { useEmilyDeposit } from "@/util/use-emily-deposit";
 import { sendBTCFordefi } from "../util/wallet-utils/src/sendBTC";
+import { getExplorerUrl } from "@/lib/get-explorer-url";
+import { getStacksNetwork } from "@/util/get-stacks-network";
 
 /*
   deposit flow has 3 steps
@@ -558,9 +560,7 @@ const DepositFlowReview = ({ txId }: DepositFlowReviewProps) => {
           <div className="w-full flex-row flex justify-between items-center">
             <a
               className="w-40 rounded-lg py-3 flex justify-center items-center flex-row bg-orange"
-              href={`https://explorer.hiro.so/txid/${stacksTxId}?chain=${
-                walletNetwork === "mainnet" ? "mainnet" : "testnet"
-              }`}
+              href={getExplorerUrl(stacksTxId, getStacksNetwork(walletNetwork))}
               target="_blank"
               rel="noreferrer"
             >

--- a/src/comps/footer.tsx
+++ b/src/comps/footer.tsx
@@ -6,6 +6,8 @@ import Image from "next/image";
 import { hexToBytes } from "@stacks/common";
 import { BridgeConfig } from "@/util/atoms";
 import getBitcoinNetwork from "@/util/get-bitcoin-network";
+import { getExplorerUrl } from "@/lib/get-explorer-url";
+import { getStacksNetwork } from "@/util/get-stacks-network";
 
 const contracts = [
   {
@@ -122,7 +124,10 @@ export default function Footer({ config }: { config: BridgeConfig }) {
               <li className="mb-1" key={contract.id}>
                 <a
                   key={contract.id}
-                  href={`https://explorer.hiro.so/txid/${config.SBTC_CONTRACT_DEPLOYER}.${contract.id}?chain=${config.WALLET_NETWORK === "mainnet" ? "mainnet" : "testnet"}`}
+                  href={getExplorerUrl(
+                    `${config.SBTC_CONTRACT_DEPLOYER}.${contract.id}`,
+                    getStacksNetwork(config.WALLET_NETWORK),
+                  )}
                   target="_blank"
                   rel="noreferrer"
                   className="text-black font-light text-sm"

--- a/src/lib/get-explorer-url.ts
+++ b/src/lib/get-explorer-url.ts
@@ -1,0 +1,7 @@
+export const getExplorerUrl = (
+  txId: string,
+  network: "devnet" | "mainnet" | "testnet",
+): string => {
+  const apiUrl = network === "devnet" ? "&api=http://localhost:3999" : "";
+  return `https://explorer.hiro.so/txid/${txId}?chain=${network}${apiUrl}`;
+};


### PR DESCRIPTION
basically I would only need the hiro stacks api to check the tx status and to get the request id, the route would work with both tx id and request id but would be faster with request id since that would be only one request to emily instead of one to the stacks api and another to emily