### PR TITLE
add actual max fee approximation to withdraw

### DIFF
--- a/src/actions/get-withdrawal-max-fee.ts
+++ b/src/actions/get-withdrawal-max-fee.ts
@@ -11,7 +11,8 @@ type mempoolFeesRes = {
   minimumFee: number;
 };
 
-const MAX_WITHDRAWAL_TX_SIZE = 320;
+// this is the case of a sweep tx fulfilling a single withdrawal to a p2wsh (32 bytes hash)
+const MAX_WITHDRAWAL_TX_SIZE = 180;
 
 export const getWithdrawalMaxFee = async () => {
   const currentMempoolFees = (await mempoolFetchUntilOk(

--- a/src/app/withdraw/components/withdraw-amount.tsx
+++ b/src/app/withdraw/components/withdraw-amount.tsx
@@ -7,11 +7,15 @@ export const WithdrawFlowAmount = ({
   handleSubmit,
   maxFee,
   disabled,
+  isFailed,
+  isLoading,
 }: {
   validationSchema: Schema;
   handleSubmit: (value: any) => void;
-  maxFee: number;
+  maxFee?: number;
   disabled?: boolean;
+  isLoading: boolean;
+  isFailed: boolean;
 }) => {
   return (
     <>
@@ -19,11 +23,19 @@ export const WithdrawFlowAmount = ({
         <Heading>Withdraw</Heading>
       </div>
       <SubText>Convert sBTC into BTC</SubText>
-      <SubText>
-        Note: An additional {Math.ceil(maxFee / 1000)}K sats will be reserved to
-        cover Bitcoin transaction fees. Any remaining amount will be
-        automatically refunded to your Stacks account as change.{" "}
-      </SubText>
+      {maxFee && (
+        <SubText>
+          Note: An additional {Math.ceil(maxFee / 1000)}K sats will be reserved
+          to cover Bitcoin transaction fees. Any remaining amount will be
+          automatically refunded to your Stacks account as change.
+        </SubText>
+      )}
+      {isFailed && (
+        <SubText>
+          Withdrawals are down due to technical issues. Please try again later.
+        </SubText>
+      )}
+      {isLoading && <SubText>Loading...</SubText>}
       <FlowForm
         disabled={disabled}
         nameKey="amount"

--- a/src/app/withdraw/components/withdraw-amount.tsx
+++ b/src/app/withdraw/components/withdraw-amount.tsx
@@ -5,10 +5,12 @@ import { Schema } from "yup";
 export const WithdrawFlowAmount = ({
   validationSchema,
   handleSubmit,
+  maxFee,
   disabled,
 }: {
   validationSchema: Schema;
   handleSubmit: (value: any) => void;
+  maxFee: number;
   disabled?: boolean;
 }) => {
   return (
@@ -18,9 +20,9 @@ export const WithdrawFlowAmount = ({
       </div>
       <SubText>Convert sBTC into BTC</SubText>
       <SubText>
-        Note: An additional 80K sats will be reserved to cover Bitcoin
-        transaction fees. Any remaining amount will be automatically refunded to
-        your Stacks account as change.{" "}
+        Note: An additional {Math.ceil(maxFee / 1000)}K sats will be reserved to
+        cover Bitcoin transaction fees. Any remaining amount will be
+        automatically refunded to your Stacks account as change.{" "}
       </SubText>
       <FlowForm
         disabled={disabled}

--- a/src/app/withdraw/components/withdraw-client.tsx
+++ b/src/app/withdraw/components/withdraw-client.tsx
@@ -223,6 +223,7 @@ const Withdraw = () => {
       {stepper.switch({
         amount: () => (
           <WithdrawFlowAmount
+            maxFee={maxFee!}
             validationSchema={amountValidationSchema as any}
             handleSubmit={(value) => {
               setFieldValue("amount", value);

--- a/src/app/withdraw/components/withdraw-client.tsx
+++ b/src/app/withdraw/components/withdraw-client.tsx
@@ -76,7 +76,11 @@ const Withdraw = () => {
     address: addresses.stacks?.address,
   });
 
-  const { data: maxFee } = useQuery({
+  const {
+    data: maxFee,
+    isError,
+    isLoading,
+  } = useQuery({
     queryKey: ["maxFee"],
     queryFn: async () => {
       return getWithdrawalMaxFee();
@@ -223,7 +227,9 @@ const Withdraw = () => {
       {stepper.switch({
         amount: () => (
           <WithdrawFlowAmount
-            maxFee={maxFee!}
+            isFailed={isError}
+            isLoading={isLoading}
+            maxFee={maxFee}
             validationSchema={amountValidationSchema as any}
             handleSubmit={(value) => {
               setFieldValue("amount", value);


### PR DESCRIPTION
This shows the estimated thousands of sats that will be reserved as max fee it assumes that it will be higher than 1K sats instead of the fixed fee (80K)

<img width="418" alt="image" src="https://github.com/user-attachments/assets/365994c1-5cf0-4a36-9168-7a5d43a6b89b" />
