### PR TITLE
only use available sbtc balance and fix validation for balance

### DIFF
--- a/src/actions/get-sbtc-balance.ts
+++ b/src/actions/get-sbtc-balance.ts
@@ -24,7 +24,7 @@ export default async function getSbtcTotalBalance({
   const response = (await fetchCallReadOnlyFunction({
     contractAddress: SBTC_CONTRACT_DEPLOYER!,
     contractName: "sbtc-token",
-    functionName: "get-balance",
+    functionName: "get-balance-available",
     functionArgs: [Cl.address(address)],
     network: network,
     senderAddress: address,

--- a/src/app/withdraw/components/withdraw-client.tsx
+++ b/src/app/withdraw/components/withdraw-client.tsx
@@ -97,24 +97,18 @@ const Withdraw = () => {
     },
   });
 
-  const {
-    data: emilyLimits,
-    refetch,
-    isLoading: emilyLimitsLoading,
-  } = useEmilyLimits();
+  const { refetch, isLoading: emilyLimitsLoading } = useEmilyLimits();
 
   const getMaxError = (maxWithdrawal: number) => {
     return `Withdrawal exceeds current cap of ${maxWithdrawal.toLocaleString(undefined, { maximumFractionDigits: 8 })} BTC`;
   };
   const amountValidationSchema = useMemo(() => {
-    const maxWithdrawal = (emilyLimits?.perWithdrawalCap || 0) / 1e8;
     const btcBalance = Number(satsBalance) / 1e8;
     const fee = maxFee! / 1e8;
     return yup.object().shape({
       amount: yup
         .number()
         .min(0)
-        .max(maxWithdrawal, getMaxError(maxWithdrawal))
         .max(
           btcBalance - fee,
           `The withdrawal + max fees (${fee.toLocaleString(undefined, { maximumFractionDigits: 8 })}) amount exceeds your current balance of ${btcBalance.toLocaleString(
@@ -126,7 +120,7 @@ const Withdraw = () => {
         )
         .required(),
     });
-  }, [emilyLimits?.perWithdrawalCap, satsBalance, maxFee]);
+  }, [satsBalance, maxFee]);
   const { WALLET_NETWORK: stacksNetwork } = useAtomValue(bridgeConfigAtom);
   const addressValidationSchema = useMemo(
     () =>


### PR DESCRIPTION
use sbtc-token balance instead of total balance and fix validation now breaks correctly if the amount is larger than the user's current sbtc balance