### PR TITLE
[feat]: cache Emily limits

### DIFF
--- a/src/actions/get-emily-limits.ts
+++ b/src/actions/get-emily-limits.ts
@@ -1,18 +1,20 @@
 "use server";
 
 import { env } from "@/env";
+
 type EmilyLimits = {
   pegCap: null | number;
   perDepositCap: null | number;
   perWithdrawalCap: null | number;
-  accountCaps: AccountCaps;
+  accountCaps: Record<string, unknown>;
   perDepositMinimum: null | number;
   availableToWithdraw: number | null;
 };
 
-type AccountCaps = {};
+let cachedValue: Awaited<ReturnType<typeof getEmilyLimitsInner>> | null = null;
+let lastFetchTime = 0; // in ms
 
-export default async function getEmilyLimits() {
+async function getEmilyLimitsInner() {
   const res = await fetch(`${env.EMILY_URL}/limits`);
   if (!res.ok) {
     return {
@@ -23,8 +25,8 @@ export default async function getEmilyLimits() {
       availableToWithdraw: 0,
     };
   }
+
   const json = (await res.json()) as EmilyLimits;
-  // exclude account caps
   return {
     pegCap: json.pegCap ?? Infinity,
     perDepositCap: json.perDepositCap ?? Infinity,
@@ -32,4 +34,20 @@ export default async function getEmilyLimits() {
     perDepositMinimum: json.perDepositMinimum ?? 0,
     availableToWithdraw: json.availableToWithdraw ?? Infinity,
   };
+}
+
+export default async function getEmilyLimits() {
+  const now = Date.now();
+  const TEN_MINUTES = 10 * 60 * 1000;
+
+  if (cachedValue && now - lastFetchTime < TEN_MINUTES) {
+    // Return cached value if fetched less than 10 minutes ago
+    return cachedValue;
+  }
+
+  // Otherwise, fetch new value and update cache
+  const newValue = await getEmilyLimitsInner();
+  cachedValue = newValue;
+  lastFetchTime = now;
+  return newValue;
 }

--- a/src/actions/get-emily-limits.ts
+++ b/src/actions/get-emily-limits.ts
@@ -6,17 +6,19 @@ type EmilyLimits = {
   pegCap: null | number;
   perDepositCap: null | number;
   perWithdrawalCap: null | number;
-  accountCaps: Record<string, unknown>;
+  accountCaps: AccountCaps;
   perDepositMinimum: null | number;
   availableToWithdraw: number | null;
 };
 
+type AccountCaps = {};
 let cachedValue: Awaited<ReturnType<typeof getEmilyLimitsInner>> | null = null;
 let lastFetchTime = 0; // in ms
 
 async function getEmilyLimitsInner() {
   const res = await fetch(`${env.EMILY_URL}/limits`);
   if (!res.ok) {
+    // exclude account caps
     return {
       pegCap: 0,
       perDepositCap: 0,

--- a/src/actions/get-emily-limits.ts
+++ b/src/actions/get-emily-limits.ts
@@ -18,7 +18,6 @@ let lastFetchTime = 0; // in ms
 async function getEmilyLimitsInner() {
   const res = await fetch(`${env.EMILY_URL}/limits`);
   if (!res.ok) {
-    // exclude account caps
     return {
       pegCap: 0,
       perDepositCap: 0,
@@ -29,6 +28,7 @@ async function getEmilyLimitsInner() {
   }
 
   const json = (await res.json()) as EmilyLimits;
+  // exclude account caps
   return {
     pegCap: json.pegCap ?? Infinity,
     perDepositCap: json.perDepositCap ?? Infinity,


### PR DESCRIPTION
Currently, the bridge polls Emily limits quite frequently. However, we do not change limits often (usually once per few months or so). Thus, this caching can eliminate a lot of Emily polls, without harming user experience too much.

Note: I choosed caching time to 1 bitcoin block more or less out of thin air and do not have a strong opinion about if this should be this amount of time or another.