### PR TITLE
Add numeric input limiting to deposit/withdraw amount inputs

### DIFF
--- a/src/app/(reskin)/components/forms/deposit/amount-input.tsx
+++ b/src/app/(reskin)/components/forms/deposit/amount-input.tsx
@@ -1,5 +1,6 @@
 import { Field, FieldProps } from "formik";
 import { InputContainer } from "../form-elements/input-container";
+import { ChangeEvent } from "react";
 
 import { Textarea } from "@/components/ui/textarea";
 
@@ -33,10 +34,30 @@ export const AmountInput = ({
           BTC
         </div>
         <Field name="amount" placeholder="Amount">
-          {({ field, meta }: FieldProps) => {
+          {({ field, meta, form }: FieldProps) => {
+            const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+              const rawValue = e.target.value;
+              const sanitizedValue = rawValue.replace(/[^0-9.]/g, "");
+
+              if (sanitizedValue === "") {
+                form.setFieldValue("amount", "");
+                return;
+              }
+
+              const parts = sanitizedValue.split(".");
+              const integerPart = parts[0].replace(/^0+/, '') || '0';
+              const decimalPart = parts.length > 1 ? parts[1] : "";
+
+              const finalValue = parts.length > 1 ? `${integerPart}.${decimalPart}` : integerPart;
+              form.setFieldValue("amount", finalValue);
+            };
+
+            const { onChange: _onChange, ...fieldProps } = field;
+
             return (
               <>
                 <Textarea
+                  onChange={handleChange}
                   onKeyUp={(e) => {
                     if (e.key === "Enter") {
                       onPressEnter?.();
@@ -49,7 +70,7 @@ export const AmountInput = ({
                   }}
                   autoFocus
                   className="text-black dark:text-white w-full bg-transparent break-all text-5xl tracking-tight h-8 placeholder:text-xl placeholder:tracking-normal text-center placeholder:text-left"
-                  {...field}
+                  {...fieldProps}
                   placeholder="Enter BTC amount to deposit"
                 />
                 {meta.touched && meta.error ? (

--- a/src/app/(reskin)/withdraw/components/form/amount-input.tsx
+++ b/src/app/(reskin)/withdraw/components/form/amount-input.tsx
@@ -1,4 +1,5 @@
 import { Field, FieldProps } from "formik";
+import { ChangeEvent } from "react";
 
 import { Textarea } from "@/components/ui/textarea";
 import { InputContainer } from "@/app/(reskin)/components/forms/form-elements/input-container";
@@ -35,10 +36,30 @@ export const AmountInput = ({
           sBTC
         </div>
         <Field name="amount" placeholder="Amount">
-          {({ field, meta }: FieldProps) => {
+          {({ field, meta, form }: FieldProps) => {
+            const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+              const rawValue = e.target.value;
+              const sanitizedValue = rawValue.replace(/[^0-9.]/g, "");
+
+              if (sanitizedValue === "") {
+                form.setFieldValue("amount", "");
+                return;
+              }
+
+              const parts = sanitizedValue.split(".");
+              const integerPart = parts[0].replace(/^0+/, '') || '0';
+              const decimalPart = parts.length > 1 ? parts[1] : "";
+
+              const finalValue = parts.length > 1 ? `${integerPart}.${decimalPart}` : integerPart;
+              form.setFieldValue("amount", finalValue);
+            };
+
+            const { onChange: _onChange, ...fieldProps } = field;
+
             return (
               <>
                 <Textarea
+                  onChange={handleChange}
                   disabled={isDisabled}
                   onKeyUp={(e) => {
                     if (e.key === "Enter") {
@@ -52,7 +73,7 @@ export const AmountInput = ({
                   }}
                   autoFocus
                   className="text-black dark:text-white w-full bg-transparent break-all text-5xl tracking-tight h-8 placeholder:text-xl placeholder:tracking-normal text-center placeholder:text-left"
-                  {...field}
+                  {...fieldProps}
                   placeholder="Enter sBTC amount to withdraw"
                 />
                 {meta.touched && meta.error ? (


### PR DESCRIPTION
## Summary
Sanitize deposit/withdraw amount inputs to allow only numeric input with a single decimal; strip invalid chars in real time.

## Changes
- `src/app/(reskin)/components/forms/deposit/amount-input.tsx`
- `src/app/(reskin)/withdraw/components/form/amount-input.tsx`
  - Strip non-numeric/non-dot
  - Coalesce multiple decimals
  - Normalize empty to "" and leading dot to "0."

## Testing
- `corepack yarn lint`
